### PR TITLE
Slå av lagring av vedtak en så lenge man går mot den samme databasen

### DIFF
--- a/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/kafka/VedtaksHendelseHåndterer.java
+++ b/domenetjenester/vedtak/src/main/java/no/nav/foreldrepenger/abakus/vedtak/kafka/VedtaksHendelseHåndterer.java
@@ -5,6 +5,8 @@ import jakarta.enterprise.context.control.ActivateRequestContext;
 import jakarta.inject.Inject;
 import jakarta.transaction.Transactional;
 
+import no.nav.foreldrepenger.konfig.KonfigVerdi;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -19,20 +21,26 @@ public class VedtaksHendelseHåndterer {
 
     private static final Logger LOG = LoggerFactory.getLogger(VedtaksHendelseHåndterer.class);
     private ProsessTaskTjeneste taskTjeneste;
+    private boolean lagreVedtak;
 
     public VedtaksHendelseHåndterer() {
         // CDI
     }
 
     @Inject
-    public VedtaksHendelseHåndterer(ProsessTaskTjeneste taskTjeneste) {
+    public VedtaksHendelseHåndterer(@KonfigVerdi(value = "kafka.lagre.vedtak", defaultVerdi = "true") Boolean lagreVedtak,
+                                    ProsessTaskTjeneste taskTjeneste) {
         this.taskTjeneste = taskTjeneste;
+        this.lagreVedtak = lagreVedtak;
     }
 
     void handleMessage(String key, String payload) {
         LOG.debug("Mottatt ytelse-vedtatt hendelse med key='{}', payload={}", key, payload);
-        var data = ProsessTaskDataBuilder.forProsessTask(LagreVedtakTask.class).medProperty(LagreVedtakTask.KEY, key).medPayload(payload);
-
-        taskTjeneste.lagre(data.build());
+        if (lagreVedtak) {
+            var data = ProsessTaskDataBuilder.forProsessTask(LagreVedtakTask.class).medProperty(LagreVedtakTask.KEY, key).medPayload(payload);
+            taskTjeneste.lagre(data.build());
+        } else {
+            LOG.info("Lagring av vedtak er slått av. Husk å slå det på igjen samtidig med k9-abakus flyttes til egen database.");
+        }
     }
 }

--- a/web/src/main/resources/application-dev-fss-k9saksbehandling.properties
+++ b/web/src/main/resources/application-dev-fss-k9saksbehandling.properties
@@ -24,9 +24,11 @@ pdl.scopes=api://dev-fss.pdl.pdl-api/.default
 # Database - brukes etter split
 # defaultDS.username=k9-abakus
 # defaultDS.url=jdbc:postgresql://b27dbvl028.preprod.local:5432/k9-abakus
+# kafka.lagre.vedtak=true
 
 defaultDS.username=fpabakus-15
 defaultDS.url=jdbc:postgresql://b27dbvl032.preprod.local:5432/fpabakus-15
+kafka.lagre.vedtak=false
 
 # FPwsProxy
 fpwsproxy.override.url=http://fpwsproxy.teamforeldrepenger/fpwsproxy

--- a/web/src/main/resources/application-prod-fss-k9saksbehandling.properties
+++ b/web/src/main/resources/application-prod-fss-k9saksbehandling.properties
@@ -24,9 +24,11 @@ pdl.scopes=api://prod-fss.pdl.pdl-api/.default
 # Database - brukes etter split
 # defaultDS.username=k9-abakus
 # defaultDS.url=jdbc:postgresql://a01dbvl034.adeo.no:5432/k9-abakus
+# kafka.lagre.vedtak=true
 
 defaultDS.username=fpabakus
 defaultDS.url=jdbc:postgresql://a01dbfl039.adeo.no:5432/fpabakus
+kafka.lagre.vedtak=false
 
 # FPwsProxy
 fpwsproxy.override.url=http://fpwsproxy.teamforeldrepenger/fpwsproxy


### PR DESCRIPTION
Planen er å flippe togglen samtidig med overgang til egen k9-abakus database.

Enn så lenge skal kun fpabakus lagre vedtak.