### PR TITLE
FIX: Swagger feiler fordi den savner loadbalancerurl, legger den til

### DIFF
--- a/.deploy/dev-fss.json
+++ b/.deploy/dev-fss.json
@@ -88,7 +88,9 @@
     "FPABAKUS_IT_PS_GRUNNLAG_URL":"http://k9-infotrygd-grunnlag-paaroerende-sykdom/paaroerendeSykdom/grunnlag",
     "FPABAKUS_IT_SP_GRUNNLAG_URL":"http://fp-infotrygd-sykepenger.teamforeldrepenger/grunnlag",
     "PDL_BASE_URL":"http://pdl-api.pdl/graphql",
-    "PDL_TEMA":"OMS"
+    "PDL_TEMA":"OMS",
+    "LOADBALANCER_URL": "https://k9-abakus.dev.intern.nav.no",
+    "LOADBALANCER_ALTERNATIVE_URL": "https://k9-abakus.dev-fss-pub.nais.io"
 
   }
 }

--- a/.deploy/prod-fss.json
+++ b/.deploy/prod-fss.json
@@ -83,6 +83,9 @@
     "FPABAKUS_IT_PS_GRUNNLAG_URL":"http://k9-infotrygd-grunnlag-paaroerende-sykdom/paaroerendeSykdom/grunnlag",
     "FPABAKUS_IT_SP_GRUNNLAG_URL":"http://fp-infotrygd-sykepenger.teamforeldrepenger/grunnlag",
     "PDL_BASE_URL":"http://pdl-api.pdl/graphql",
-    "PDL_TEMA":"OMS"
+    "PDL_TEMA":"OMS",
+    "LOADBALANCER_URL": "https://k9-abakus.intern.nav.no",
+    "LOADBALANCER_ALTERNATIVE_URL": "https://k9-abakus.prod-fss-pub.nais.io"
+
   }
 }


### PR DESCRIPTION
Jeg fikk den her da jeg prøvde å bruke swagger:

```
<head></head><h2 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(0, 0, 0); font-family: Times; font-variant-ligatures: normal; orphans: 2; widows: 2; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">HTTP ERROR 500 TekniskException:F-720999:Mangler nødvendig system property 'loadbalancer.url'</h2>
URI: | /k9/abakus/swagger
-- | --
500
TekniskException:F-720999:Mangler nødvendig system property 'loadbalancer.url'
default
TekniskException:F-720999:Mangler nødvendig system property 'loadbalancer.url'

<h3 style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(0, 0, 0); font-family: Times; font-variant-ligatures: normal; orphans: 2; widows: 2; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">Caused by:</h3><pre style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; text-align: start; text-indent: 0px; text-transform: none; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration: none; color: rgb(0, 0, 0); font-variant-ligatures: normal; orphans: 2; widows: 2; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">TekniskException:F-720999:Mangler nødvendig system property 'loadbalancer.url'
	at no.nav.k9.felles.oidc.config.ServerInfo.lambda$schemeHostPortFromSystemProperties$0(ServerInfo.java:75)
	at java.base/java.util.Optional.orElseThrow(Unknown Source)
	at no.nav.k9.felles.konfigurasjon.env.Environment.getRequiredProperty(Environment.java:129)
	at no.nav.k9.felles.oidc.config.ServerInfo.schemeHostPortFromSystemProperties(ServerInfo.java:74)
	at no.nav.k9.felles.oidc.config.ServerInfo.&lt;init&gt;(ServerInfo.java:29)
	at no.nav.k9.felles.oidc.config.ServerInfo.instance(ServerInfo.java:46)
	at no.nav.k9.felles.oidc.ressurs.ExtractRequestDataHelp.getOriginalUrl(ExtractRequestDataHelp.java:31)
	at no.nav.k9.felles.sikkerhet.jaspic.OidcAuthModule.responseUnAuthorized(OidcAuthModule.java:337)
	at no.nav.k9.felles.sikkerhet.jaspic.OidcAuthModule.validateRequest(OidcAuthModule.java:135)
	at org.eclipse.jetty.ee9.security.jaspi.provider.SimpleServerAuthContext.validateRequest(SimpleServerAuthContext.java:45)</pre>
```

Så da legger jeg til `loadbalancer.url` da.