### PR TITLE
equals og hashcode i implementasjoner av PersonIdent

### DIFF
--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/AktørIdPersonident.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/AktørIdPersonident.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(value = Include.NON_ABSENT, content = Include.NON_EMPTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -34,5 +36,15 @@ public class AktørIdPersonident extends PersonIdent {
     @Override
     public String getIdentType() {
         return IDENT_TYPE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof AktørIdPersonident annen && ident.equals(annen.ident);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ident);
     }
 }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/FnrPersonident.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/FnrPersonident.java
@@ -10,6 +10,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonInclude(value = Include.NON_ABSENT, content = Include.NON_EMPTY)
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
@@ -34,5 +36,15 @@ public class FnrPersonident extends PersonIdent {
     @Override
     public String getIdentType() {
         return IDENT_TYPE;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        return o instanceof FnrPersonident annen && ident.equals(annen.ident);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(ident);
     }
 }


### PR DESCRIPTION
> InntektsmeldingCacheNøkkel i k9-sak benytter instanser av PersonIdent i sin equals, det kan umulig fungere så bra uten at equals er implementert i PersonIdent-klassene

Jeg så feil, equals er implementert i en superklasse, så da bør det jo fungere fint