### PR TITLE
TSFF-2113: Utvid Inntektsmelding med InntektsmeldingType

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
@@ -34,6 +34,7 @@ import no.nav.k9.abakus.felles.diff.ChangeTracked;
 import no.nav.k9.abakus.felles.diff.IndexKeyComposer;
 import no.nav.k9.abakus.felles.jpa.BaseEntitet;
 import no.nav.k9.abakus.iay.jpa.InntektsmeldingInnsendingsårsakKodeverdiConverter;
+import no.nav.k9.abakus.iay.jpa.InntektsmeldingTypeKodeverdiConverter;
 import no.nav.k9.abakus.typer.Beløp;
 import no.nav.k9.abakus.typer.InternArbeidsforholdRef;
 import no.nav.k9.abakus.typer.JournalpostId;
@@ -139,6 +140,7 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
     @ChangeTracked
     private InntektsmeldingInnsendingsårsakType innsendingsårsak = InntektsmeldingInnsendingsårsakType.UDEFINERT;
 
+    @Convert(converter = InntektsmeldingTypeKodeverdiConverter.class)
     @Column(name = "inntektsmelding_type", updatable = false)
     private InntektsmeldingType inntektsmeldingType;
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
@@ -469,11 +469,23 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
 
     @Override
     public String toString() {
-        return getClass().getSimpleName() + "<" + "id=" + id + ", virksomhet=" + arbeidsgiver + ", arbeidsforholdId='" + arbeidsforholdRef + '\''
-            + ", startDatoPermisjon=" + startDatoPermisjon + ", nærRelasjon=" + nærRelasjon + ", journalpostId=" + journalpostId + ", inntektBeløp="
-            + inntektBeløp + ", refusjonBeløpPerMnd=" + refusjonBeløpPerMnd + ", refusjonOpphører=" + refusjonOpphører + ", innsendingsårsak= "
-            + innsendingsårsak + ", innsendingstidspunkt= " + innsendingstidspunkt + ", kanalreferanse=" + kanalreferanse + ", kildesystem="
-            + kildesystem + ", mottattDato=" + mottattDato + '>';
+        return getClass().getSimpleName()
+            + "<" + "id=" + id
+            + ", virksomhet=" + arbeidsgiver
+            + ", arbeidsforholdId='" + arbeidsforholdRef + '\''
+            + ", startDatoPermisjon=" + startDatoPermisjon
+            + ", nærRelasjon=" + nærRelasjon
+            + ", journalpostId=" + journalpostId
+            + ", inntektBeløp=" + inntektBeløp
+            + ", refusjonBeløpPerMnd=" + refusjonBeløpPerMnd
+            + ", refusjonOpphører=" + refusjonOpphører
+            + ", innsendingsårsak= " + innsendingsårsak
+            + ", innsendingstidspunkt= " + innsendingstidspunkt
+            + ", kanalreferanse=" + kanalreferanse
+            + ", kildesystem=" + kildesystem
+            + ", mottattDato=" + mottattDato
+            + ", inntektsmeldingType=" + inntektsmeldingType
+            + '>';
     }
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
@@ -27,6 +27,7 @@ import jakarta.persistence.Version;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.IndexKey;
 import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingInnsendingsårsakType;
+import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingType;
 import no.nav.k9.abakus.domene.iay.Arbeidsgiver;
 import no.nav.k9.abakus.domene.iay.InntektsmeldingAggregat;
 import no.nav.k9.abakus.felles.diff.ChangeTracked;
@@ -138,6 +139,9 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
     @ChangeTracked
     private InntektsmeldingInnsendingsårsakType innsendingsårsak = InntektsmeldingInnsendingsårsakType.UDEFINERT;
 
+    @Column(name = "inntektsmelding_type")
+    private InntektsmeldingType inntektsmeldingType;
+
     @Version
     @Column(name = "versjon", nullable = false)
     private long versjon;
@@ -227,6 +231,14 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
 
     void setInnsendingstidspunkt(LocalDateTime innsendingstidspunkt) {
         this.innsendingstidspunkt = innsendingstidspunkt;
+    }
+
+    public InntektsmeldingType getInntektsmeldingType() {
+        return inntektsmeldingType;
+    }
+
+    void setInntektsmeldingType(InntektsmeldingType inntektsmeldingType) {
+        this.inntektsmeldingType = inntektsmeldingType;
     }
 
     public String getKanalreferanse() {

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/Inntektsmelding.java
@@ -139,7 +139,7 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
     @ChangeTracked
     private InntektsmeldingInnsendingsårsakType innsendingsårsak = InntektsmeldingInnsendingsårsakType.UDEFINERT;
 
-    @Column(name = "inntektsmelding_type")
+    @Column(name = "inntektsmelding_type", updatable = false)
     private InntektsmeldingType inntektsmeldingType;
 
     @Version
@@ -166,6 +166,7 @@ public class Inntektsmelding extends BaseEntitet implements IndexKey {
         this.kanalreferanse = inntektsmelding.getKanalreferanse();
         this.kildesystem = inntektsmelding.getKildesystem();
         this.mottattDato = inntektsmelding.getMottattDato();
+        this.inntektsmeldingType = inntektsmelding.getInntektsmeldingType();
 
         this.graderinger = inntektsmelding.getGraderinger().stream().map(g -> {
             var data = new Gradering(g);

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/InntektsmeldingBuilder.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/domene/iay/inntektsmelding/InntektsmeldingBuilder.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 import java.util.Optional;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingInnsendingsårsakType;
+import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingType;
 import no.nav.k9.abakus.domene.iay.Arbeidsgiver;
 import no.nav.k9.abakus.typer.Beløp;
 import no.nav.k9.abakus.typer.EksternArbeidsforholdRef;
@@ -109,6 +110,12 @@ public class InntektsmeldingBuilder {
     public InntektsmeldingBuilder medKanalreferanse(String kanalreferanse) {
         precondition();
         kladd.setKanalreferanse(kanalreferanse);
+        return this;
+    }
+
+    public InntektsmeldingBuilder medInntektsmeldingType(InntektsmeldingType inntektsmeldingType) {
+        precondition();
+        kladd.setInntektsmeldingType(inntektsmeldingType);
         return this;
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/jpa/InntektsmeldingTypeKodeverdiConverter.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/jpa/InntektsmeldingTypeKodeverdiConverter.java
@@ -1,0 +1,19 @@
+package no.nav.k9.abakus.iay.jpa;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingType;
+
+@Converter(autoApply = true)
+public class InntektsmeldingTypeKodeverdiConverter implements AttributeConverter<InntektsmeldingType, String> {
+    @Override
+    public String convertToDatabaseColumn(InntektsmeldingType attribute) {
+        return attribute == null ? null : attribute.getKode();
+    }
+
+    @Override
+    public InntektsmeldingType convertToEntityAttribute(String dbData) {
+        return dbData == null ? null : InntektsmeldingType.fraKode(dbData);
+    }
+}

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/tjeneste/dto/iay/MapInntektsmeldinger.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/tjeneste/dto/iay/MapInntektsmeldinger.java
@@ -130,6 +130,7 @@ public class MapInntektsmeldinger {
                 .medInntektBeløp(im.getInntektBeløp().getVerdi())
                 .medKanalreferanse(im.getKanalreferanse())
                 .medKildesystem(im.getKildesystem())
+                .medInntektsmeldingType(im.getInntektsmeldingType())
                 .medRefusjonOpphører(im.getRefusjonOpphører())
                 .medRefusjonsBeløpPerMnd(im.getRefusjonBeløpPerMnd() == null ? null : im.getRefusjonBeløpPerMnd().getVerdi())
                 .medStartDatoPermisjon(im.getStartDatoPermisjon())
@@ -246,6 +247,7 @@ public class MapInntektsmeldinger {
                 .medInntektsmeldingaarsak(innsendingsårsak)
                 .medNærRelasjon(dto.isNærRelasjon() == null ? false : dto.isNærRelasjon())
                 .medKildesystem(dto.getKildesystem())
+                .medInntektsmeldingType(dto.getInntektsmeldingType())
                 .medMottattDato(dto.getMottattDato());
 
             dto.getEndringerRefusjon().stream().map(eir -> new Refusjon(eir.getRefusjonsbeløpMnd(), eir.getFom())).forEach(builder::leggTil);

--- a/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
+++ b/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
@@ -1,8 +1,58 @@
 package no.nav.abakus.iaygrunnlag.kodeverk;
 
-public enum InntektsmeldingType {
-    ORDINÆR,
-    OMSORGSPENGER_REFUSJON,
-    ARBEIDSGIVERINITIERT_NYANSATT,
-    ARBEIDSGIVERINITIERT_UREGISTRERT
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+@JsonAutoDetect(getterVisibility = Visibility.NONE, setterVisibility = Visibility.NONE, fieldVisibility = Visibility.ANY)
+public enum InntektsmeldingType implements Kodeverdi {
+    ORDINÆR("ORDINÆR", "Ordinær"),
+    OMSORGSPENGER_REFUSJON("OMSORGSPENGER_REFUSJON", "Omsorgspenger refusjon"),
+    ARBEIDSGIVERINITIERT_NYANSATT("ARBEIDSGIVERINITIERT_NYANSATT", "Arbeidsgiverinitiert nyansatt"),
+    ARBEIDSGIVERINITIERT_UREGISTRERT("ARBEIDSGIVERINITIERT_UREGISTRERT", "Arbeidsgiverinitiert uregistrert"),
+    UDEFINERT("-", "Ikke definert");
+
+    private static final Map<String, InntektsmeldingType> KODER = new LinkedHashMap<>();
+
+    static {
+        for (var v : values()) {
+            if (KODER.putIfAbsent(v.kode, v) != null) {
+                throw new IllegalArgumentException("Duplikat : " + v.kode);
+            }
+        }
+    }
+
+    @JsonValue
+    private final String kode;
+    private final String navn;
+
+    InntektsmeldingType(String kode, String navn) {
+        this.kode = kode;
+        this.navn = navn;
+    }
+
+    public static InntektsmeldingType fraKode(String kode) {
+        if (kode == null) {
+            return null;
+        }
+        return Optional.ofNullable(KODER.get(kode)).orElseThrow(() -> new IllegalArgumentException("Ukjent InntektsmeldingType: " + kode));
+    }
+
+    public static Map<String, InntektsmeldingType> kodeMap() {
+        return Collections.unmodifiableMap(KODER);
+    }
+
+    @Override
+    public String getKode() {
+        return kode;
+    }
+
+    public String getNavn() {
+        return navn;
+    }
 }

--- a/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
+++ b/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
@@ -1,0 +1,8 @@
+package no.nav.abakus.iaygrunnlag.kodeverk;
+
+public enum InntektsmeldingType {
+    ORDINÆR,
+    OMSORGSPENGER_REFUSJON,
+    ARBEIDSGIVERINITIERT_NYANSATT,
+    ARBEIDSGIVERINITIERT_UREGISTRERT
+}

--- a/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
+++ b/kodeverk/src/main/java/no/nav/abakus/iaygrunnlag/kodeverk/InntektsmeldingType.java
@@ -14,8 +14,7 @@ public enum InntektsmeldingType implements Kodeverdi {
     ORDINÆR("ORDINÆR", "Ordinær"),
     OMSORGSPENGER_REFUSJON("OMSORGSPENGER_REFUSJON", "Omsorgspenger refusjon"),
     ARBEIDSGIVERINITIERT_NYANSATT("ARBEIDSGIVERINITIERT_NYANSATT", "Arbeidsgiverinitiert nyansatt"),
-    ARBEIDSGIVERINITIERT_UREGISTRERT("ARBEIDSGIVERINITIERT_UREGISTRERT", "Arbeidsgiverinitiert uregistrert"),
-    UDEFINERT("-", "Ikke definert");
+    ARBEIDSGIVERINITIERT_UREGISTRERT("ARBEIDSGIVERINITIERT_UREGISTRERT", "Arbeidsgiverinitiert uregistrert");
 
     private static final Map<String, InntektsmeldingType> KODER = new LinkedHashMap<>();
 

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/inntektsmelding/v1/InntektsmeldingDto.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/inntektsmelding/v1/InntektsmeldingDto.java
@@ -15,6 +15,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
+import no.nav.abakus.iaygrunnlag.kodeverk.InntektsmeldingType;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
@@ -112,6 +113,9 @@ public class InntektsmeldingDto {
     @NotNull
     private InntektsmeldingInnsendingsårsakType innsendingsårsak;
 
+    @JsonProperty(value = "inntektsmeldingType")
+    private InntektsmeldingType inntektsmeldingType;
+
     public InntektsmeldingDto(Aktør arbeidsgiver, JournalpostId journalpostId, LocalDateTime innsendingstidspunkt, LocalDate mottattDato) {
         Objects.requireNonNull(arbeidsgiver, "arbeidsgiver");
         Objects.requireNonNull(journalpostId, "journalpostId");
@@ -185,6 +189,14 @@ public class InntektsmeldingDto {
 
     public void setKanalreferanse(String kanalreferanse) {
         this.kanalreferanse = kanalreferanse;
+    }
+
+    public InntektsmeldingType getInntektsmeldingType() {
+        return inntektsmeldingType;
+    }
+
+    public void setInntektsmeldingType(InntektsmeldingType inntektsmeldingType) {
+        this.inntektsmeldingType = inntektsmeldingType;
     }
 
     public String getKildesystem() {
@@ -292,6 +304,11 @@ public class InntektsmeldingDto {
 
     public InntektsmeldingDto medKildesystem(String kildesystem) {
         setKildesystem(kildesystem);
+        return this;
+    }
+
+    public InntektsmeldingDto medInntektsmeldingType(InntektsmeldingType inntektsmeldingType) {
+        setInntektsmeldingType(inntektsmeldingType);
         return this;
     }
 

--- a/migreringer/src/main/resources/db/postgres/defaultDS/2.2/V2.2_002__add_inntektsmeldingtype_column.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/2.2/V2.2_002__add_inntektsmeldingtype_column.sql
@@ -1,0 +1,5 @@
+-- Add inntektsmeldingType column to iay_inntektsmelding table
+ALTER TABLE iay_inntektsmelding ADD COLUMN inntektsmeldingtype VARCHAR(50);
+
+-- Add comment for the new column
+COMMENT ON COLUMN iay_inntektsmelding.inntektsmeldingtype IS 'Type inntektsmelding';

--- a/migreringer/src/main/resources/db/postgres/defaultDS/2.2/V2.2_002__add_inntektsmeldingtype_column.sql
+++ b/migreringer/src/main/resources/db/postgres/defaultDS/2.2/V2.2_002__add_inntektsmeldingtype_column.sql
@@ -1,5 +1,5 @@
 -- Add inntektsmeldingType column to iay_inntektsmelding table
-ALTER TABLE iay_inntektsmelding ADD COLUMN inntektsmeldingtype VARCHAR(50);
+ALTER TABLE iay_inntektsmelding ADD COLUMN inntektsmelding_type VARCHAR(50);
 
 -- Add comment for the new column
-COMMENT ON COLUMN iay_inntektsmelding.inntektsmeldingtype IS 'Type inntektsmelding';
+COMMENT ON COLUMN iay_inntektsmelding.inntektsmelding_type IS 'Type inntektsmelding';


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi har behov for å lagre InntektsmeldingType i inntektsmeldingen slik at k9-sak kan godta inntektsmeldinger som ikke ligger på skjæringstidspunkt dersom de er av typen ARBEIDSGIVERINITIERT.

Jira: https://jira.adeo.no/browse/TSFF-2113

### **Løsning**
Utvider InntektsmeldingDto og InntektsmeldingEntiteten med InntektsmeldingType

### Relaterte PR-er
- https://github.com/navikt/k9-inntektsmelding/pull/518
- https://github.com/navikt/k9-sak/pull/12191