### PR TITLE
Erstatter ikke-godkjente fødselsnummer med fiktive FNR fra godkjent liste

### DIFF
--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/inntekt/sigrun/PgiFolketrygdenResponseTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/inntekt/sigrun/PgiFolketrygdenResponseTest.java
@@ -23,7 +23,7 @@ class PgiFolketrygdenResponseTest {
     // Erstattet FASTLAND / "pensjonsgivendeInntektAvNaeringsinntektFraFiskeFangstEllerFamiliebarnehage": 85000 med null for testformål
     private static final String SKATT_EKSEMPEL = """
         {
-            "norskPersonidentifikator": "02116049964",
+            "norskPersonidentifikator": "01017000299",
             "inntektsaar": 2019,
             "pensjonsgivendeInntekt": [
                 {


### PR DESCRIPTION
## Erstatter ikke-godkjente fødselsnummer

Bytter ut fødselsnummer som ikke er på [godkjent liste](https://github.com/navikt/sif-gha-workflows/tree/main/.github/actions/sif-code-scan/allowed-fnr) med fiktive fødselsnummer fra sif-gha-workflows allowed-fnr.

Dette sikrer at `sif-code-scan` ikke feiler i CI/CD-pipeline.