### PR TITLE
Erstatt fiktive fødselsnummer med syntetisk fnr

### DIFF
--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/inntekt/sigrun/PgiFolketrygdenResponseTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/inntekt/sigrun/PgiFolketrygdenResponseTest.java
@@ -23,7 +23,7 @@ class PgiFolketrygdenResponseTest {
     // Erstattet FASTLAND / "pensjonsgivendeInntektAvNaeringsinntektFraFiskeFangstEllerFamiliebarnehage": 85000 med null for testformål
     private static final String SKATT_EKSEMPEL = """
         {
-            "norskPersonidentifikator": "01017000299",
+            "norskPersonidentifikator": "23500180528",
             "inntektsaar": 2019,
             "pensjonsgivendeInntekt": [
                 {


### PR DESCRIPTION
Erstatter gamle fiktive FNR brukt i tester med nytt fiktivt syntetiske personnummer (23500180528) som automatisk ignoreres av sif-code-scan.

Relatert til navikt/sif-gha-workflows#280