### PR TITLE
Logger ikke når det er flere meldekort i Kelvin enn i Arena, ettersom…

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -176,9 +176,9 @@ public class InnhentingSamletTjeneste {
             var mAIkkeK = arenaMK.stream().filter(a -> kelvinMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
             var mKIkkeA = kelvinMK.stream().filter(a -> arenaMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
             if (kelvin.isEmpty() && !arena.isEmpty()) {
-                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke var i Kelvin: {}", vKIkkeA);
+                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke var i Kelvin: {}", vAIkkeK);
             } else if (arena.size() > kelvin.size()) {
-                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}",  vKIkkeA);
+                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}",  vAIkkeK);
             } else if (!arena.isEmpty()) {
                 var likeNokVedtak = arena.stream().allMatch(a -> kelvin.stream().anyMatch(a::likeNokVedtak));
                 var likeMk = kelvinMK.containsAll(arenaMK);

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -175,10 +175,10 @@ public class InnhentingSamletTjeneste {
                 .map(MeldekortUtbetalingsgrunnlagSak::utskriftUtenMK).collect(Collectors.joining(", "));
             var mAIkkeK = arenaMK.stream().filter(a -> kelvinMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
             var mKIkkeA = kelvinMK.stream().filter(a -> arenaMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
-            if (arena.isEmpty() ^ kelvin.isEmpty()) {
-                LOG.info("Maksimum AAP sammenligning ene er tom:  arena: {} mk {} kelvin: {} mk {}", vAIkkeK, mAIkkeK, vKIkkeA, mKIkkeA);
-            } else if (arena.size() != kelvin.size() || arenaMK.size() != kelvinMK.size()) {
-                LOG.info("Maksimum AAP sammenligning ulik størrelse:  arena: {} mk {} kelvin: {} mk {}", vAIkkeK, mAIkkeK, vKIkkeA, mKIkkeA);
+            if (kelvin.isEmpty() && !arena.isEmpty()) {
+                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke var i Kelvin: {}", vKIkkeA);
+            } else if (arena.size() > kelvin.size()) {
+                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}",  vKIkkeA);
             } else if (!arena.isEmpty()) {
                 var likeNokVedtak = arena.stream().allMatch(a -> kelvin.stream().anyMatch(a::likeNokVedtak));
                 var likeMk = kelvinMK.containsAll(arenaMK);

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -175,9 +175,7 @@ public class InnhentingSamletTjeneste {
                 .map(MeldekortUtbetalingsgrunnlagSak::utskriftUtenMK).collect(Collectors.joining(", "));
             var mAIkkeK = arenaMK.stream().filter(a -> kelvinMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
             var mKIkkeA = kelvinMK.stream().filter(a -> arenaMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
-            if (kelvin.isEmpty() && !arena.isEmpty()) {
-                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke var i Kelvin: {}", vAIkkeK);
-            } else if (arena.size() > kelvin.size()) {
+            if (arena.size() > kelvin.size()) {
                 LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}",  vAIkkeK);
             } else if (!arena.isEmpty()) {
                 var likeNokVedtak = arena.stream().allMatch(a -> kelvin.stream().anyMatch(a::likeNokVedtak));


### PR DESCRIPTION
… dette er forventet

Siden flere og flere saker behandles i Kelvin og ikke i Arena, så er det forventa at Kelvin har flere meldekort enn Arena. Derimot skal vi ikke få meldekort fra Arena som vi ikke får fra Kelvin, siden Kelvin skal hente de aktuelle meldekortene fra Arena for oss, så logger ut om det er avvik her.