### PR TITLE
chore: GitHub governance-oppsett

### DIFF
--- a/.github/instructions/governance-review-okonomi.instructions.md
+++ b/.github/instructions/governance-review-okonomi.instructions.md
@@ -1,0 +1,31 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Økonomireglementet — spesielle hensyn
+
+Denne kodebasen forvalter ytelser og utbetalinger underlagt økonomireglementet (Reglement for økonomistyring i staten).
+Copilot skal spesielt vurdere følgende:
+
+## Uhensiktsmessig spesialbehandling
+- Flag kode som innfører logikk for å behandle enkeltpersoner, enkeltorganisasjoner eller spesifikke saker ulikt uten saklig grunnlag
+- Eksempler: hardkodede aktørId-er, fødselsnumre, saksnumre eller organisasjonsnumre som styrer forretningslogikk
+- Unntak: testdata, feiltoleransefiltre med tydelig midlertidig kommentar og tilhørende oppfølgingssak
+
+## Flyway-migrasjoner (økonomisk data)
+- Migrasjonsfiler som endrer tabeller med finansielle data (ytelse, beregning, oppdrag, tilbakekreving, vedtak, utbetaling, refusjon)
+- Destruktive migrasjoner (DROP TABLE, DROP COLUMN, ALTER COLUMN type change) på produksjonstabeller
+- Manglende eller feil versjonsnummerering i migrasjonsfiler
+- Migrasjoner som endrer beregningsgrunnlag, satser eller vedtaksdata krever ekstra oppmerksomhet
+
+## Sporbarhet og begrunnelse
+- Sjekk at PR-beskrivelsen inneholder minst én av:
+  - Lenke til Jira-sak, GitHub issue eller Slack-tråd
+  - En tydelig beskrivelse av **hvorfor** endringen gjøres
+- Endringer i forretningslogikk uten sporbar begrunnelse skal flagges
+
+## Rimelighet og proporsjonalitet
+- Vurder om endringene er rimelige i omfang relativt til beskrevet behov
+- Flag hvis endringen har utilsiktede sideeffekter på beregning eller utbetaling
+- Varsle hvis feilhåndtering endres på måter som kan føre til feilutbetalinger eller tapte krav

--- a/.github/instructions/governance-review-okonomi.instructions.md
+++ b/.github/instructions/governance-review-okonomi.instructions.md
@@ -9,7 +9,7 @@ Denne kodebasen forvalter ytelser og utbetalinger underlagt økonomireglementet 
 Copilot skal spesielt vurdere følgende:
 
 ## Uhensiktsmessig spesialbehandling
-- Flag kode som innfører logikk for å behandle enkeltpersoner, enkeltorganisasjoner eller spesifikke saker ulikt uten saklig grunnlag
+- Flagg kode som innfører logikk for å behandle enkeltpersoner, enkeltorganisasjoner eller spesifikke saker ulikt uten saklig grunnlag
 - Eksempler: hardkodede aktørId-er, fødselsnumre, saksnumre eller organisasjonsnumre som styrer forretningslogikk
 - Unntak: testdata, feiltoleransefiltre med tydelig midlertidig kommentar og tilhørende oppfølgingssak
 
@@ -27,5 +27,5 @@ Copilot skal spesielt vurdere følgende:
 
 ## Rimelighet og proporsjonalitet
 - Vurder om endringene er rimelige i omfang relativt til beskrevet behov
-- Flag hvis endringen har utilsiktede sideeffekter på beregning eller utbetaling
+- Flagg hvis endringen har utilsiktede sideeffekter på beregning eller utbetaling
 - Varsle hvis feilhåndtering endres på måter som kan føre til feilutbetalinger eller tapte krav

--- a/.github/instructions/governance-review.instructions.md
+++ b/.github/instructions/governance-review.instructions.md
@@ -11,7 +11,7 @@ Disse instruksjonene gjelder for GitHub Copilot code review for alle filer i det
 
 ### Branch-navngivning
 Flag dersom source branch ikke følger navnekonvensjon. Forventede prefikser:
-- `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `ci/`, `dependabot/`, `renovate/`
+- `feature/`, `fix/`, `chore/`, `docs/`
 
 ### Relevans
 Verifiser at endringene er rimelige i omfang og relevante for oppgitt formål.

--- a/.github/instructions/governance-review.instructions.md
+++ b/.github/instructions/governance-review.instructions.md
@@ -1,0 +1,60 @@
+---
+applyTo: "**"
+excludeAgent: "cloud-agent"
+---
+
+# Generelle review-instruksjoner
+
+Disse instruksjonene gjelder for GitHub Copilot code review for alle filer i dette repoet.
+
+## Generelle sjekker
+
+### Branch-navngivning
+Flag dersom source branch ikke følger navnekonvensjon. Forventede prefikser:
+- `feature/`, `fix/`, `chore/`, `docs/`, `refactor/`, `test/`, `ci/`, `dependabot/`, `renovate/`
+
+### Relevans
+Verifiser at endringene er rimelige i omfang og relevante for oppgitt formål.
+Flag dersom PRen inneholder urelaterte endringer blandet inn.
+
+## Domene-spesifikke punkter
+
+Flag følgende for menneskelig reviewer. Ikke blokker — fremhev med kommentar.
+
+### NAIS-konfigurasjon
+- Endringer i `nais*.yaml` eller `naiserator.yaml` som modifiserer:
+  - `accessPolicy` (inbound/outbound-regler)
+  - `env`-variabler (spesielt secrets, SCOPE, credentials)
+  - `azure.application` eller `tokenx`-konfigurasjon
+  - Ressursgrenser eller replicas
+
+### Autentisering og autorisasjon
+- Endringer i kode som håndterer tokens, OIDC, SAML, `@BeskyttetRessurs` eller `@ProtectedWithClaims`
+- Endringer i ABAC policy-evaluering eller tilgangssjekker
+- Nye eller endrede API-endepunkter som endrer tilgangskontroll
+
+### ProsessTask og jobbstyring
+- Nye `ProsessTask`-implementasjoner eller endringer i task type-definisjoner
+- Endringer i cron-uttrykk eller konfigurering av planlagte jobber
+- Endringer i retry-logikk eller feilhåndtering i asynkrone tasks
+
+### Integrasjonspunkter
+- Endringer i klienter som kaller eksterne systemer (spesielt Økonomi/OS, Infotrygd, PDL, Dokarkiv)
+- Endringer i Kafka-produsenter/konsumenter (topic-navn, serialisering, feilhåndtering)
+- Nye eller endrede REST/SOAP-klientkonfigurasjoner
+
+### Miljøvariabler og hemmeligheter
+- Nye eller endrede miljøvariabler som inneholder `SCOPE`, `CLIENT_ID`, `CLIENT_SECRET` eller `CREDENTIAL`
+- Referanser til Vault eller Azure Key Vault-hemmeligheter
+- Hardkodede URLer, tokens eller credentials (flag som sikkerhetsproblem)
+
+### GitHub Actions workflows
+- Endringer i `.github/workflows/` som påvirker bygg, test eller deploy-pipelines
+- Fjerning eller svekkelse av teststeg
+- Endringer i deployment-targets eller betingelser
+- Upinnede action-versjoner (bør bruke SHA eller versjonstagg)
+
+### Test- og deployment-sikringer
+- Fjerning av test-assertions eller testfiler uten erstatning
+- Endringer som hopper over eller deaktiverer tester (`@Disabled`, `skipTests`)
+- Modifikasjoner av deployment-guards eller approval-gates

--- a/.github/instructions/governance-review.instructions.md
+++ b/.github/instructions/governance-review.instructions.md
@@ -10,16 +10,16 @@ Disse instruksjonene gjelder for GitHub Copilot code review for alle filer i det
 ## Generelle sjekker
 
 ### Branch-navngivning
-Flag dersom source branch ikke følger navnekonvensjon. Forventede prefikser:
+Flagg dersom source branch ikke følger navnekonvensjon. Forventede prefikser:
 - `feature/`, `fix/`, `chore/`, `docs/`
 
 ### Relevans
 Verifiser at endringene er rimelige i omfang og relevante for oppgitt formål.
-Flag dersom PRen inneholder urelaterte endringer blandet inn.
+Flagg dersom PRen inneholder urelaterte endringer blandet inn.
 
 ## Domene-spesifikke punkter
 
-Flag følgende for menneskelig reviewer. Ikke blokker — fremhev med kommentar.
+Flagg følgende for menneskelig reviewer. Ikke blokker — fremhev med kommentar.
 
 ### NAIS-konfigurasjon
 - Endringer i `nais*.yaml` eller `naiserator.yaml` som modifiserer:
@@ -46,7 +46,7 @@ Flag følgende for menneskelig reviewer. Ikke blokker — fremhev med kommentar.
 ### Miljøvariabler og hemmeligheter
 - Nye eller endrede miljøvariabler som inneholder `SCOPE`, `CLIENT_ID`, `CLIENT_SECRET` eller `CREDENTIAL`
 - Referanser til Vault eller Azure Key Vault-hemmeligheter
-- Hardkodede URLer, tokens eller credentials (flag som sikkerhetsproblem)
+- Hardkodede URLer, tokens eller credentials (flagg som sikkerhetsproblem)
 
 ### GitHub Actions workflows
 - Endringer i `.github/workflows/` som påvirker bygg, test eller deploy-pipelines

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,3 +1,22 @@
-flyway:
+kontrakt:
+- any:
   - changed-files:
-      - any-glob-to-any-file: 'migreringer/src/main/resources/db/postgres/**'
+    - any-glob-to-any-file: "kontrakt/src/main/java/**/*"
+    - any-glob-to-any-file: "kontrakt-vedtak/src/main/java/**/*"
+    - any-glob-to-any-file: "kodeverk/src/main/java/**/*"
+
+migreringer:
+- any:
+  - changed-files:
+    - any-glob-to-any-file: "migreringer/src/main/resources/**/*"
+
+web:
+- any:
+  - changed-files:
+    - any-glob-to-any-file: "web/src/main/java/**/*"
+
+pom:
+- any:
+  - changed-files:
+    - any-glob-to-any-file: "**/*/pom.xml"
+    - any-glob-to-any-file: "pom.xml"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,22 +1,3 @@
-kontrakt:
-- any:
+flyway:
   - changed-files:
-    - any-glob-to-any-file: "kontrakt/src/main/java/**/*"
-    - any-glob-to-any-file: "kontrakt-vedtak/src/main/java/**/*"
-    - any-glob-to-any-file: "kodeverk/src/main/java/**/*"
-
-migreringer:
-- any:
-  - changed-files:
-    - any-glob-to-any-file: "migreringer/src/main/resources/**/*"
-
-web:
-- any:
-  - changed-files:
-    - any-glob-to-any-file: "web/src/main/java/**/*"
-
-pom:
-- any:
-  - changed-files:
-    - any-glob-to-any-file: "**/*/pom.xml"
-    - any-glob-to-any-file: "pom.xml"
+      - any-glob-to-any-file: 'migreringer/src/main/resources/db/postgres/**'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,4 @@
 
 - [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
 - [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
-- [ ] Behov for endringen er tilstrekkelig beskrevet og virker rimelig
-- [ ] Sporbarhet: lenke til diskusjon i Slack, Jira, GitHub issue eller tilsvarende
+- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+### Behov / Bakgrunn
+
+
+### Løsning
+
+
+### Andre endringer
+
+
+---
+
+### Sjekkliste for godkjenner
+
+- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
+- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
+- [ ] Behov for endringen er tilstrekkelig beskrevet og virker rimelig
+- [ ] Sporbarhet: lenke til diskusjon i Slack, Jira, GitHub issue eller tilsvarende


### PR DESCRIPTION
Standardiserer governance-filer på tvers av teamets repoer for å sikre konsistent CODEOWNERS, review-instruksjoner, PR-mal og eventuelle labels.

Filene vedlikeholdes sentralt i [sif-team/governance](https://github.com/navikt/sif-team/tree/main/governance) og distribueres med `distribute_files.sh`.