### PR TITLE
Oppdater k9-prosesstask til versjon 6.0.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
             <dependency>
                 <groupId>no.nav.k9.prosesstask</groupId>
                 <artifactId>prosesstask-root</artifactId>
-                <version>6.0.11</version>
+                <version>6.0.13</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
### Behov / Bakgrunn

Ny versjon av `k9-prosesstask` er tilgjengelig (6.0.13). Holder avhengigheten oppdatert.

### Løsning

Oppdaterer `prosesstask-root` BOM-versjon i rot-`pom.xml` fra forrige versjon til `6.0.13`.

### Andre endringer

Ingen.

---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres