### PR TITLE
Integrasjon med dp-sak, stort sett kopiert fra Foreldrepenger

### DIFF
--- a/.deploy/dev-fss.json
+++ b/.deploy/dev-fss.json
@@ -91,6 +91,5 @@
 
     "KELVIN_URL": "https://aap-api.intern.dev.nav.no",
     "KELVIN_SCOPE": "api://dev-gcp.aap.api-intern/.default",
-    "SKAL_HENTE_DAGPEMGER_FRA_DPSAK": "true"
   }
 }

--- a/.deploy/dev-fss.json
+++ b/.deploy/dev-fss.json
@@ -67,7 +67,7 @@
     "DEFAULTDS_URL": "jdbc:postgresql://b27dbvl028.preprod.local:5432/k9-abakus",
     "FPWSPROXY_OVERRIDE_URL": "http://fpwsproxy.teamforeldrepenger/fpwsproxy",
     "FPWSPROXY_SCOPE": "api://dev-fss.teamforeldrepenger.fpwsproxy/.default",
-    "DAGPENGER_SCOPE": "api://dev-gcp.teamdagpenger.dp-datadeling",
+    "DAGPENGERDATADELING_SCOPE":  "api://dev-gcp.teamdagpenger.dp-datadeling/.default",
     "DAGPENGERDATADELING_BASE_URL": "https://dp-datadeling.intern.dev.nav.no",
     "CLIENT_SCOPE": "api://dev-fss.k9saksbehandling.k9-abakus/.default",
 

--- a/.deploy/dev-fss.json
+++ b/.deploy/dev-fss.json
@@ -67,6 +67,8 @@
     "DEFAULTDS_URL": "jdbc:postgresql://b27dbvl028.preprod.local:5432/k9-abakus",
     "FPWSPROXY_OVERRIDE_URL": "http://fpwsproxy.teamforeldrepenger/fpwsproxy",
     "FPWSPROXY_SCOPE": "api://dev-fss.teamforeldrepenger.fpwsproxy/.default",
+    "DAGPENGER_SCOPE": "api://dev-gcp.teamdagpenger.dp-datadeling",
+    "DAGPENGERDATADELING_BASE_URL": "https://dp-datadeling.intern.dev.nav.no",
     "CLIENT_SCOPE": "api://dev-fss.k9saksbehandling.k9-abakus/.default",
 
     "SIF_ABAC_PDP_K9_SCOPE": "api://dev-fss.k9saksbehandling.sif-abac-pdp/.default",
@@ -89,5 +91,6 @@
 
     "KELVIN_URL": "https://aap-api.intern.dev.nav.no",
     "KELVIN_SCOPE": "api://dev-gcp.aap.api-intern/.default",
+    "SKAL_HENTE_DAGPEMGER_FRA_DPSAK": "true"
   }
 }

--- a/.deploy/prod-fss.json
+++ b/.deploy/prod-fss.json
@@ -67,6 +67,8 @@
     "DEFAULTDS_URL":"jdbc:postgresql://a01dbvl034.adeo.no:5432/k9-abakus",
     "FPWSPROXY_OVERRIDE_URL":"http://fpwsproxy.teamforeldrepenger/fpwsproxy",
     "FPWSPROXY_SCOPE":"api://prod-fss.teamforeldrepenger.fpwsproxy/.default",
+    "DAGPENGERDATADELING_SCOPE": "api://prod-gcp.teamdagpenger.dp-datadeling/.default",
+    "DAGPENGERDATADELING_URL": "https://dp-datadeling.intern.nav.no",
     "CLIENT_SCOPE": "api://prod-fss.k9saksbehandling.k9-abakus/.default",
 
     "SIF_ABAC_PDP_K9_SCOPE": "api://prod-fss.k9saksbehandling.sif-abac-pdp/.default",
@@ -89,5 +91,6 @@
 
     "KELVIN_URL": "https://aap-api.intern.nav.no",
     "KELVIN_SCOPE": "api://prod-gcp.aap.api-intern/.default",
+    "SKAL_HENTE_DAGPEMGER_FRA_DPSAK": "false"
   }
 }

--- a/.deploy/prod-fss.json
+++ b/.deploy/prod-fss.json
@@ -68,7 +68,7 @@
     "FPWSPROXY_OVERRIDE_URL":"http://fpwsproxy.teamforeldrepenger/fpwsproxy",
     "FPWSPROXY_SCOPE":"api://prod-fss.teamforeldrepenger.fpwsproxy/.default",
     "DAGPENGERDATADELING_SCOPE": "api://prod-gcp.teamdagpenger.dp-datadeling/.default",
-    "DAGPENGERDATADELING_URL": "https://dp-datadeling.intern.nav.no",
+    "DAGPENGERDATADELING_BASE_URL": "https://dp-datadeling.intern.nav.no",
     "CLIENT_SCOPE": "api://prod-fss.k9saksbehandling.k9-abakus/.default",
 
     "SIF_ABAC_PDP_K9_SCOPE": "api://prod-fss.k9saksbehandling.sif-abac-pdp/.default",

--- a/.deploy/prod-fss.json
+++ b/.deploy/prod-fss.json
@@ -91,6 +91,5 @@
 
     "KELVIN_URL": "https://aap-api.intern.nav.no",
     "KELVIN_SCOPE": "api://prod-gcp.aap.api-intern/.default",
-    "SKAL_HENTE_DAGPEMGER_FRA_DPSAK": "false"
   }
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -106,19 +106,15 @@ public class InnhentingSamletTjeneste {
         return innhentingInfotrygdTjeneste.getSPøkelseYtelser(ident, periode.getFomDato());
     }
 
-    public Map<Fagsystem, List<DpsakVedtak>> innhentDagpengerDpsak(PersonIdent ident,
+    public Map<Fagsystem, List<DpsakVedtak>> innhentDagpengerDpSak(PersonIdent ident,
                                                                    IntervallEntitet opplysningsPeriode,
                                                                    Saksnummer saksnummer,
                                                                    List<MeldekortUtbetalingsgrunnlagSak> grunnlagFraArena) {
         var antallVedtak = grunnlagFraArena.size();
         var antallMeldekort = grunnlagFraArena.stream()
-            .mapToInt(s -> Optional.ofNullable(s.getMeldekortene()).orElseGet(List::of).size())
+            .mapToInt(sak -> Optional.ofNullable(sak.getMeldekortene()).orElseGet(List::of).size())
             .sum();
-        var vedtak = dpsakRestKlient.hentDagpenger(ident, opplysningsPeriode.getFomDato(), opplysningsPeriode.getTomDato(), saksnummer, antallVedtak, antallMeldekort);
-        if (!vedtak.getOrDefault(Fagsystem.DPSAK, List.of()).isEmpty()) {
-            LOG.info("DP-DATADELING vedtak {}", vedtak);
-        }
-        return vedtak;
+        return dpsakRestKlient.hentDagpenger(ident, opplysningsPeriode.getFomDato(), opplysningsPeriode.getTomDato(), saksnummer, antallVedtak, antallMeldekort);
     }
 
     public List<MeldekortUtbetalingsgrunnlagSak> hentAapFraKelvin(

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
 
-import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakKlient;
+import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakRestKlient;
 import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakVedtak;
 
 import org.slf4j.Logger;
@@ -49,7 +49,7 @@ public class InnhentingSamletTjeneste {
     private FpwsproxyKlient fpwsproxyKlient;
     private InnhentingInfotrygdTjeneste innhentingInfotrygdTjeneste;
     private KelvinRestKlient kelvinRestKlient;
-    private DpsakKlient dpsakKlient;
+    private DpsakRestKlient dpsakRestKlient;
 
     InnhentingSamletTjeneste() {
         //CDI
@@ -61,7 +61,7 @@ public class InnhentingSamletTjeneste {
                                     InnhentingInfotrygdTjeneste innhentingInfotrygdTjeneste,
                                     FpwsproxyKlient fpwsproxyKlient,
                                     KelvinRestKlient kelvinRestKlient,
-                                    DpsakKlient dpsakKlient
+                                    DpsakRestKlient dpsakRestKlient
                                     ) {
 
         this.arbeidsforholdTjeneste = arbeidsforholdTjeneste;
@@ -69,7 +69,7 @@ public class InnhentingSamletTjeneste {
         this.fpwsproxyKlient = fpwsproxyKlient;
         this.innhentingInfotrygdTjeneste = innhentingInfotrygdTjeneste;
         this.kelvinRestKlient = kelvinRestKlient;
-        this.dpsakKlient = dpsakKlient;
+        this.dpsakRestKlient = dpsakRestKlient;
     }
 
 
@@ -114,7 +114,7 @@ public class InnhentingSamletTjeneste {
         var antallMeldekort = grunnlagFraArena.stream()
             .mapToInt(s -> Optional.ofNullable(s.getMeldekortene()).orElseGet(List::of).size())
             .sum();
-        var vedtak = dpsakKlient.hentDagpenger(ident, opplysningsPeriode.getFomDato(), opplysningsPeriode.getTomDato(), saksnummer, antallVedtak, antallMeldekort);
+        var vedtak = dpsakRestKlient.hentDagpenger(ident, opplysningsPeriode.getFomDato(), opplysningsPeriode.getTomDato(), saksnummer, antallVedtak, antallMeldekort);
         if (!vedtak.getOrDefault(Fagsystem.DPSAK, List.of()).isEmpty()) {
             LOG.info("DP-DATADELING vedtak {}", vedtak);
         }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -106,7 +106,8 @@ public class InnhentingSamletTjeneste {
         return innhentingInfotrygdTjeneste.getSPøkelseYtelser(ident, periode.getFomDato());
     }
 
-    public Map<Fagsystem, List<DpsakVedtak>> innhentDagpengerDpsak(PersonIdent ident, IntervallEntitet opplysningsPeriode,
+    public Map<Fagsystem, List<DpsakVedtak>> innhentDagpengerDpsak(PersonIdent ident,
+                                                                   IntervallEntitet opplysningsPeriode,
                                                                    Saksnummer saksnummer,
                                                                    List<MeldekortUtbetalingsgrunnlagSak> grunnlagFraArena) {
         var antallVedtak = grunnlagFraArena.size();

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -5,10 +5,14 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
+
+import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakKlient;
+import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakVedtak;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,6 +49,7 @@ public class InnhentingSamletTjeneste {
     private FpwsproxyKlient fpwsproxyKlient;
     private InnhentingInfotrygdTjeneste innhentingInfotrygdTjeneste;
     private KelvinRestKlient kelvinRestKlient;
+    private DpsakKlient dpsakKlient;
 
     InnhentingSamletTjeneste() {
         //CDI
@@ -55,14 +60,16 @@ public class InnhentingSamletTjeneste {
                                     InntektTjeneste inntektTjeneste,
                                     InnhentingInfotrygdTjeneste innhentingInfotrygdTjeneste,
                                     FpwsproxyKlient fpwsproxyKlient,
-                                    KelvinRestKlient kelvinRestKlient
-    ) {
+                                    KelvinRestKlient kelvinRestKlient,
+                                    DpsakKlient dpsakKlient
+                                    ) {
 
         this.arbeidsforholdTjeneste = arbeidsforholdTjeneste;
         this.inntektTjeneste = inntektTjeneste;
         this.fpwsproxyKlient = fpwsproxyKlient;
         this.innhentingInfotrygdTjeneste = innhentingInfotrygdTjeneste;
         this.kelvinRestKlient = kelvinRestKlient;
+        this.dpsakKlient = dpsakKlient;
     }
 
 
@@ -97,6 +104,20 @@ public class InnhentingSamletTjeneste {
 
     public List<InfotrygdYtelseGrunnlag> innhentSpokelseGrunnlag(PersonIdent ident, @SuppressWarnings("unused") IntervallEntitet periode) {
         return innhentingInfotrygdTjeneste.getSPøkelseYtelser(ident, periode.getFomDato());
+    }
+
+    public Map<Fagsystem, List<DpsakVedtak>> innhentDagpengerDpsak(PersonIdent ident, IntervallEntitet opplysningsPeriode,
+                                                                   Saksnummer saksnummer,
+                                                                   List<MeldekortUtbetalingsgrunnlagSak> grunnlagFraArena) {
+        var antallVedtak = grunnlagFraArena.size();
+        var antallMeldekort = grunnlagFraArena.stream()
+            .mapToInt(s -> Optional.ofNullable(s.getMeldekortene()).orElseGet(List::of).size())
+            .sum();
+        var vedtak = dpsakKlient.hentDagpenger(ident, opplysningsPeriode.getFomDato(), opplysningsPeriode.getTomDato(), saksnummer, antallVedtak, antallMeldekort);
+        if (!vedtak.getOrDefault(Fagsystem.DPSAK, List.of()).isEmpty()) {
+            LOG.info("DP-DATADELING vedtak {}", vedtak);
+        }
+        return vedtak;
     }
 
     public List<MeldekortUtbetalingsgrunnlagSak> hentAapFraKelvin(

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -64,7 +64,7 @@ public class YtelseRegisterInnhenting {
         }
 
         var dagsaker = arena.stream().filter(s -> YtelseType.DAGPENGER.equals(s.getYtelseType())).toList();
-        var dagpenger = innhentingSamletTjeneste.innhentDagpengerDpsak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
+        var dagpenger = innhentingSamletTjeneste.innhentDagpengerDpSak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
 
         for (var dpsakvedtak : dagpenger.getOrDefault(Fagsystem.DPSAK, List.of())) {
             oversettDpsakTilYtelse(aktørYtelseBuilder, dpsakvedtak);

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -1,11 +1,16 @@
 package no.nav.k9.abakus.registerdata;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
 import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
 import no.nav.k9.abakus.domene.iay.InntektArbeidYtelseAggregatBuilder;
 import no.nav.k9.abakus.domene.iay.YtelseBuilder;
 import no.nav.k9.abakus.felles.jpa.IntervallEntitet;
@@ -13,8 +18,10 @@ import no.nav.k9.abakus.kobling.Kobling;
 import no.nav.k9.abakus.registerdata.infotrygd.InfotrygdgrunnlagYtelseMapper;
 import no.nav.k9.abakus.registerdata.ytelse.arena.MeldekortUtbetalingsgrunnlagMeldekort;
 import no.nav.k9.abakus.registerdata.ytelse.arena.MeldekortUtbetalingsgrunnlagSak;
+import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakVedtak;
 import no.nav.k9.abakus.registerdata.ytelse.infotrygd.dto.InfotrygdYtelseGrunnlag;
 import no.nav.k9.abakus.typer.AktørId;
+import no.nav.k9.abakus.typer.Beløp;
 import no.nav.k9.abakus.typer.PersonIdent;
 import no.nav.k9.abakus.typer.Saksnummer;
 
@@ -56,6 +63,13 @@ public class YtelseRegisterInnhenting {
             oversettMeldekortUtbetalingsgrunnlagTilYtelse(aktørYtelseBuilder, sak);
         }
 
+        var dagsaker = arena.stream().filter(s -> YtelseType.DAGPENGER.equals(s.getYtelseType())).toList();
+        var dpdatadeling = innhentingSamletTjeneste.innhentDagpengerDpsak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
+
+        for (var dpsakvedtak : dpdatadeling.getOrDefault(Fagsystem.DPSAK, List.of())) {
+            oversettDpsakTilYtelse(aktørYtelseBuilder, dpsakvedtak);
+        }
+
         var aapFraArena = arena.stream().filter(s -> YtelseType.ARBEIDSAVKLARINGSPENGER.equals(s.getYtelseType())).toList();
         List<MeldekortUtbetalingsgrunnlagSak> aapFraKelvin = innhentingSamletTjeneste.hentAapFraKelvin(ident, opplysningsPeriode, behandling.getSaksnummer(), aapFraArena);
 
@@ -79,6 +93,35 @@ public class YtelseRegisterInnhenting {
             ytelseBuilder.leggtilYtelseAnvist(
                 ytelseBuilder.getAnvistBuilder().medAnvistPeriode(intervall).medUtbetalingsgradProsent(vedtak.getUtbetalingsgrad()).build());
         });
+        aktørYtelseBuilder.leggTilYtelse(ytelseBuilder);
+    }
+
+    // Tolker bare dagpenger fra DP-sak. Dapenger fra Arena via dp-datadeling blir en egen vurdering senere.
+    // Forutsetter: Utbetaling har lik dagsats og lik utbetaltBeløp for alle dager i perioden (vilkårlig lengde). sumUtbetalt = utbetaltBeløp * virkedager.
+    private void oversettDpsakTilYtelse(InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder aktørYtelseBuilder, DpsakVedtak dagpengerVedtak) {
+        var førsteUtbetalingFom = dagpengerVedtak.utbetalinger().stream()
+            .map(DpsakVedtak.DpsakUtbetaling::periode)
+            .map(LocalDateInterval::getFomDato)
+            .min(Comparator.naturalOrder());
+        var periode = IntervallEntitet.fraOgMedTilOgMed(dagpengerVedtak.periode().getFomDato(), dagpengerVedtak.periode().getTomDato());
+        var status = LocalDate.now().isBefore(dagpengerVedtak.periode().getTomDato()) ? YtelseStatus.LØPENDE : YtelseStatus.AVSLUTTET;
+        var ytelseBuilder = aktørYtelseBuilder.getYtelselseBuilderForType(Fagsystem.DPSAK, YtelseType.DAGPENGER, periode, førsteUtbetalingFom);
+        ytelseBuilder.medPeriode(periode)
+            .medStatus(status)
+            .medYtelseGrunnlag(ytelseBuilder.getGrunnlagBuilder()
+                .medVedtaksDagsats(new Beløp(BigDecimal.valueOf(dagpengerVedtak.dagsats())))
+                .build());
+        for (var utbetaling : dagpengerVedtak.utbetalinger()) {
+            var dagsats = BigDecimal.valueOf(utbetaling.dagsats());
+            var utbetalingsgrad = BigDecimal.valueOf(utbetaling.utbetaltBeløp()).multiply(BigDecimal.valueOf(100))
+                .divide(dagsats, 1, RoundingMode.HALF_UP);
+            ytelseBuilder.leggtilYtelseAnvist(ytelseBuilder.getAnvistBuilder()
+                .medAnvistPeriode(IntervallEntitet.fraOgMedTilOgMed(utbetaling.periode().getFomDato(), utbetaling.periode().getTomDato()))
+                .medBeløp(BigDecimal.valueOf(utbetaling.sumUtbetalt()))
+                .medDagsats(dagsats)
+                .medUtbetalingsgradProsent(utbetalingsgrad)
+                .build());
+        }
         aktørYtelseBuilder.leggTilYtelse(ytelseBuilder);
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -96,9 +96,10 @@ public class YtelseRegisterInnhenting {
         aktørYtelseBuilder.leggTilYtelse(ytelseBuilder);
     }
 
+    // Kpiert fra fp-abakus
     // Tolker bare dagpenger fra DP-sak. Dapenger fra Arena via dp-datadeling blir en egen vurdering senere.
     // Forutsetter: Utbetaling har lik dagsats og lik utbetaltBeløp for alle dager i perioden (vilkårlig lengde). sumUtbetalt = utbetaltBeløp * virkedager.
-    private void oversettDpsakTilYtelse(InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder aktørYtelseBuilder, DpsakVedtak dagpengerVedtak) {
+    void oversettDpsakTilYtelse(InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder aktørYtelseBuilder, DpsakVedtak dagpengerVedtak) {
         var førsteUtbetalingFom = dagpengerVedtak.utbetalinger().stream()
             .map(DpsakVedtak.DpsakUtbetaling::periode)
             .map(LocalDateInterval::getFomDato)

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -96,8 +96,8 @@ public class YtelseRegisterInnhenting {
         aktørYtelseBuilder.leggTilYtelse(ytelseBuilder);
     }
 
-    // Kpiert fra fp-abakus
-    // Tolker bare dagpenger fra DP-sak. Dapenger fra Arena via dp-datadeling blir en egen vurdering senere.
+    // Kopiert fra fp-abakus
+    // Tolker bare dagpenger fra DP-sak. Dagpenger fra Arena via dp-datadeling blir en egen vurdering senere.
     // Forutsetter: Utbetaling har lik dagsats og lik utbetaltBeløp for alle dager i perioden (vilkårlig lengde). sumUtbetalt = utbetaltBeløp * virkedager.
     void oversettDpsakTilYtelse(InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder aktørYtelseBuilder, DpsakVedtak dagpengerVedtak) {
         var førsteUtbetalingFom = dagpengerVedtak.utbetalinger().stream()

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -64,9 +64,9 @@ public class YtelseRegisterInnhenting {
         }
 
         var dagsaker = arena.stream().filter(s -> YtelseType.DAGPENGER.equals(s.getYtelseType())).toList();
-        var dpdatadeling = innhentingSamletTjeneste.innhentDagpengerDpsak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
+        var dagpenger = innhentingSamletTjeneste.innhentDagpengerDpsak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
 
-        for (var dpsakvedtak : dpdatadeling.getOrDefault(Fagsystem.DPSAK, List.of())) {
+        for (var dpsakvedtak : dagpenger.getOrDefault(Fagsystem.DPSAK, List.of())) {
             oversettDpsakTilYtelse(aktørYtelseBuilder, dpsakvedtak);
         }
 
@@ -113,7 +113,7 @@ public class YtelseRegisterInnhenting {
                 .build());
         for (var utbetaling : dagpengerVedtak.utbetalinger()) {
             var dagsats = BigDecimal.valueOf(utbetaling.dagsats());
-            var utbetalingsgrad = BigDecimal.valueOf(utbetaling.utbetaltBeløp()).multiply(BigDecimal.valueOf(100))
+            var utbetalingsgrad = BigDecimal.valueOf(utbetaling.dagutbetalt()).multiply(BigDecimal.valueOf(100))
                 .divide(dagsats, 1, RoundingMode.HALF_UP);
             ytelseBuilder.leggtilYtelseAnvist(ytelseBuilder.getAnvistBuilder()
                 .medAnvistPeriode(IntervallEntitet.fraOgMedTilOgMed(utbetaling.periode().getFomDato(), utbetaling.periode().getTomDato()))

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhenting.java
@@ -63,7 +63,7 @@ public class YtelseRegisterInnhenting {
             oversettMeldekortUtbetalingsgrunnlagTilYtelse(aktørYtelseBuilder, sak);
         }
 
-        var dagsaker = arena.stream().filter(s -> YtelseType.DAGPENGER.equals(s.getYtelseType())).toList();
+        var dagsaker = arena.stream().filter(sak -> YtelseType.DAGPENGER.equals(sak.getYtelseType())).toList();
         var dagpenger = innhentingSamletTjeneste.innhentDagpengerDpSak(ident, opplysningsPeriode, behandling.getSaksnummer(), dagsaker);
 
         for (var dpsakvedtak : dagpenger.getOrDefault(Fagsystem.DPSAK, List.of())) {

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerKilde.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerKilde.java
@@ -1,0 +1,6 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+public enum DagpengerKilde {
+    DP_SAK,
+    ARENA
+}

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerRettighetsperioderDto.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerRettighetsperioderDto.java
@@ -7,7 +7,5 @@ public record DagpengerRettighetsperioderDto(String personIdent, List<Rettighets
 
     public record Rettighetsperiode(LocalDate fraOgMedDato, LocalDate tilOgMedDato, DagpengerKilde kilde) {
     }
-
-    public enum DagpengerKilde { DP_SAK, ARENA }
 }
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerRettighetsperioderDto.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerRettighetsperioderDto.java
@@ -1,0 +1,13 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record DagpengerRettighetsperioderDto(String personIdent, List<Rettighetsperiode> perioder) {
+
+    public record Rettighetsperiode(LocalDate fraOgMedDato, LocalDate tilOgMedDato, DagpengerKilde kilde) {
+    }
+
+    public enum DagpengerKilde { DP_SAK, ARENA }
+}
+

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerUtbetalingDto.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerUtbetalingDto.java
@@ -2,6 +2,7 @@ package no.nav.k9.abakus.registerdata.ytelse.dpsak;
 
 import java.time.LocalDate;
 
+// Kommer i perioder på 1 dag fra kilde DP-sak og 14 dager fra Arena
 public record DagpengerUtbetalingDto(LocalDate fraOgMed, LocalDate tilOgMed, DagpengerKilde kilde,
                                      Integer sats, Integer utbetaltBeløp, Integer gjenståendeDager) {
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerUtbetalingDto.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DagpengerUtbetalingDto.java
@@ -1,0 +1,8 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import java.time.LocalDate;
+
+public record DagpengerUtbetalingDto(LocalDate fraOgMed, LocalDate tilOgMed, DagpengerKilde kilde,
+                                     Integer sats, Integer utbetaltBeløp, Integer gjenståendeDager) {
+}
+

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakKlient.java
@@ -41,11 +41,6 @@ public class DpsakKlient {
     public DpsakKlient() {
     }
 
-
-    public record PersonRequest(String personIdent, LocalDate fraOgMedDato, LocalDate tilOgMedDato) {
-    }
-
-
     public Map<Fagsystem, List<DpsakVedtak>> hentDagpenger(PersonIdent personIdent, LocalDate fom, LocalDate tom, Saksnummer sak,
                                                            int antallArenaVedtak, int antallArenaMeldekort) {
         try {
@@ -99,5 +94,8 @@ public class DpsakKlient {
             throw new IllegalArgumentException("Utviklerfeil syntax-exception for hentDagpenger fra dp-sak");
         }
     }
+
+    private record PersonRequest(String personIdent, LocalDate fraOgMedDato, LocalDate tilOgMedDato) { }
+
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakKlient.java
@@ -1,0 +1,103 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import java.net.URI;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.core.UriBuilder;
+import jakarta.ws.rs.core.UriBuilderException;
+import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
+import no.nav.k9.abakus.typer.PersonIdent;
+import no.nav.k9.abakus.typer.Saksnummer;
+import no.nav.k9.felles.integrasjon.rest.ScopedRestIntegration;
+import no.nav.k9.felles.integrasjon.rest.SystemUserOidcRestClient;
+import no.nav.k9.felles.konfigurasjon.konfig.KonfigVerdi;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// https://navikt.github.io/dp-datadeling/openapi.html
+@ApplicationScoped
+@ScopedRestIntegration(scopeKey = "dagpenger.scope", defaultScope = "api://prod-gcp.teamdagpenger.dp-datadeling/.default/.default")
+public class DpsakKlient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DpsakKlient.class);
+
+    private URI beregningerEndpoint;
+    private URI rettighetsperioderEndpoint;
+    private SystemUserOidcRestClient restClient;
+
+    @Inject
+    public DpsakKlient(SystemUserOidcRestClient restClient, @KonfigVerdi(value = "dagpengerdatadeling.base.url") URI dagpengerUrl) {
+        beregningerEndpoint = UriBuilder.fromUri(dagpengerUrl).path("/dagpenger/datadeling/v1/beregninger").build();
+        rettighetsperioderEndpoint = UriBuilder.fromUri(dagpengerUrl).path("/dagpenger/datadeling/v1/perioder").build();
+        this.restClient = restClient;
+    }
+
+    public DpsakKlient() {
+    }
+
+
+    public record PersonRequest(String personIdent, LocalDate fraOgMedDato, LocalDate tilOgMedDato) {
+    }
+
+
+    public Map<Fagsystem, List<DpsakVedtak>> hentDagpenger(PersonIdent personIdent, LocalDate fom, LocalDate tom, Saksnummer sak,
+                                                           int antallArenaVedtak, int antallArenaMeldekort) {
+        try {
+            var perioder = hentRettighetsperioder(personIdent, fom, tom);
+            var utbetalinger = hentUtbetalinger(personIdent, fom, tom);
+            var perioderArena = perioder.stream()
+                .filter(p -> DagpengerRettighetsperioderDto.DagpengerKilde.ARENA.equals(p.kilde()))
+                .toList();
+            var perioderDpsak = perioder.stream()
+                .filter(p -> DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK.equals(p.kilde()))
+                .toList();
+            var utbetalingerDpsak = utbetalinger.stream()
+                .filter(u -> DagpengerKilde.DP_SAK.equals(u.kilde()))
+                .toList();
+            var utbetalingerArena = utbetalinger.stream()
+                .filter(u -> DagpengerKilde.ARENA.equals(u.kilde()))
+                .toList();
+            if (!perioderArena.isEmpty() || !utbetalingerArena.isEmpty()) {
+                LOG.info("DP-DATADELING ARENA fant {} perioder og {} utbetalinger mot {} vedtak og {} MK fra Arena",
+                    perioderArena.size(), utbetalingerArena.size(), antallArenaVedtak, antallArenaMeldekort);
+            }
+            if (!perioderDpsak.isEmpty() || !utbetalingerDpsak.isEmpty()) {
+                LOG.info("DP-DATADELING DPSAK fant {} perioder og {} utbetalinger. Perioder: {}. Utbetalinger {}",
+                    perioderDpsak.size(), utbetalingerDpsak.size(), perioderDpsak, utbetalingerDpsak);
+                LOG.warn("Merk Dem! Sak {} har nye dagpenger. Kontakt produkteier umiddelbart", sak.getVerdi());
+            }
+            var dpsakVedtak = DpsakMapper.fullMapping(perioderDpsak, utbetalingerDpsak);
+            return Map.of(Fagsystem.DPSAK, dpsakVedtak);
+        } catch (Exception e) {
+            LOG.info("DP-DATADELING feil ", e);
+            return Map.of();
+        }
+    }
+
+    public List<DagpengerRettighetsperioderDto.Rettighetsperiode> hentRettighetsperioder(PersonIdent personIdent, LocalDate fom, LocalDate tom) {
+        var prequest = new PersonRequest(personIdent.getIdent(), fom, tom);
+        try {
+            var result = restClient.post(rettighetsperioderEndpoint, prequest, DagpengerRettighetsperioderDto.class);
+            return result.perioder();
+        } catch (UriBuilderException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Utviklerfeil syntax-exception for hentDagpenger fra dp-sak");
+        }
+    }
+
+    public List<DagpengerUtbetalingDto> hentUtbetalinger(PersonIdent personIdent, LocalDate fom, LocalDate tom) {
+        var prequest = new PersonRequest(personIdent.getIdent(), fom, tom);
+        try {
+            var result = restClient.post(beregningerEndpoint, prequest, DagpengerUtbetalingDto[].class);
+            return Arrays.stream(result).toList();
+        } catch (UriBuilderException | IllegalArgumentException e) {
+            throw new IllegalArgumentException("Utviklerfeil syntax-exception for hentDagpenger fra dp-sak");
+        }
+    }
+
+}

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
@@ -30,7 +30,7 @@ public class DpsakMapper {
                 .filter(v -> Objects.equals(v.dagsats(), u.getValue().sats()) && v.periode().overlaps(u.getLocalDateInterval()))
                 .findFirst().orElseThrow(() -> new IllegalStateException("Fant ikke utbetaling " + u + " i noen vedtak " + vedtakene));
             var du = new DpsakVedtak.DpsakUtbetaling(u.getLocalDateInterval().extendThroughWeekend(),
-                u.getValue().sats(), u.getValue().utbetaltBeløp(), u.getValue().sumUtbetalt());
+                u.getValue().sats(), u.getValue().utbetaltForDag(), u.getValue().sumUtbetalt());
             vedtak.utbetalinger().add(du);
         });
         return vedtakene;
@@ -68,7 +68,7 @@ public class DpsakMapper {
         return max.equals(utbetaling.tilOgMed()) ? null : utbetaling.tilOgMed();
     }
 
-    private record MappedUtbetaling(Integer sats, Integer utbetaltBeløp, Integer sumUtbetalt) implements Comparable<MappedUtbetaling> {
+    private record MappedUtbetaling(Integer sats, Integer utbetaltForDag, Integer sumUtbetalt) implements Comparable<MappedUtbetaling> {
 
         MappedUtbetaling(DagpengerUtbetalingDto utbetaling) {
             this(utbetaling.sats(), utbetaling.utbetaltBeløp(), utbetaling.utbetaltBeløp());
@@ -76,19 +76,19 @@ public class DpsakMapper {
 
         @Override
         public int compareTo(MappedUtbetaling o) {
-            var utbetaltDiff = Integer.compare(this.utbetaltBeløp, o.utbetaltBeløp);
+            var utbetaltDiff = Integer.compare(this.utbetaltForDag, o.utbetaltForDag);
             return utbetaltDiff == 0 ? Integer.compare(this.sats, o.sats) : utbetaltDiff;
         }
 
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
-            return o instanceof MappedUtbetaling that && sats.equals(that.sats) && utbetaltBeløp.equals(that.utbetaltBeløp);
+            return o instanceof MappedUtbetaling that && sats.equals(that.sats) && utbetaltForDag.equals(that.utbetaltForDag);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(sats, utbetaltBeløp);
+            return Objects.hash(sats, utbetaltForDag);
         }
     }
 
@@ -109,8 +109,8 @@ public class DpsakMapper {
     private static LocalDateSegment<MappedUtbetaling> slåSammen(LocalDateInterval i,
                                                                 LocalDateSegment<MappedUtbetaling> lhs,
                                                                 LocalDateSegment<MappedUtbetaling> rhs) {
-        return new LocalDateSegment<>(i, new MappedUtbetaling(lhs.getValue().sats(), lhs.getValue().utbetaltBeløp(),
-            lhs.getValue().sumUtbetalt() + rhs.getValue().utbetaltBeløp()));
+        return new LocalDateSegment<>(i, new MappedUtbetaling(lhs.getValue().sats(), lhs.getValue().utbetaltForDag(),
+            lhs.getValue().sumUtbetalt() + rhs.getValue().sumUtbetalt()));
     }
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
@@ -1,0 +1,116 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+import no.nav.fpsak.tidsserie.LocalDateSegment;
+import no.nav.fpsak.tidsserie.LocalDateTimeline;
+import no.nav.fpsak.tidsserie.StandardCombinators;
+
+public class DpsakMapper {
+
+    private DpsakMapper() {
+    }
+
+    static List<DpsakVedtak> fullMapping(List<DagpengerRettighetsperioderDto.Rettighetsperiode> rettighetsperioder,
+                                         List<DagpengerUtbetalingDto> utbetalinger) {
+        // Deler opp rettighetsperioder etter dagsats og utbetalingsdatoer med dagsats. Lager vedtak fra disse
+        var vedtakene = mapDatadelingVedtak(rettighetsperioder, utbetalinger).stream()
+            .map(v -> new DpsakVedtak(v.getLocalDateInterval(), v.getValue(), new ArrayList<>()))
+            .toList();
+        // Henter utbetalingstidslinje med summert ubetalt og helge-extender disse
+        mapDatadelingDpsakUtbetaling(utbetalinger).forEach(u -> {
+            var vedtak = vedtakene.stream()
+                .filter(v -> Objects.equals(v.dagsats(), u.getValue().sats()) && v.periode().overlaps(u.getLocalDateInterval()))
+                .findFirst().orElseThrow(() -> new IllegalStateException("Fant ikke utbetaling " + u + " i noen vedtak " + vedtakene));
+            var du = new DpsakVedtak.DpsakUtbetaling(u.getLocalDateInterval().extendThroughWeekend(),
+                u.getValue().sats(), u.getValue().utbetaltBeløp(), u.getValue().sumUtbetalt());
+            vedtak.utbetalinger().add(du);
+        });
+        return vedtakene;
+    }
+
+    private static LocalDateTimeline<Integer> mapDatadelingVedtak(List<DagpengerRettighetsperioderDto.Rettighetsperiode> rettighetsperioder,
+                                                                  List<DagpengerUtbetalingDto> utbetalinger) {
+        // Tidslinje for rettighetsperioder
+        var rettighetsperioderTidslinje = rettighetsperioder.stream()
+            .map(p -> new LocalDateSegment<>(p.fraOgMedDato(), p.tilOgMedDato(), 0))
+            .collect(Collectors.collectingAndThen(Collectors.toList(),
+                l -> new LocalDateTimeline<>(l, StandardCombinators::max)))
+            .compress();
+        if (utbetalinger.isEmpty()) {
+            return rettighetsperioderTidslinje;
+        } else {
+            // Extender seneste utbetalingsdato og antar at siste dagsats gjelder framover.
+            var maxUtbetalt = utbetalinger.stream().map(DagpengerUtbetalingDto::tilOgMed).max(Comparator.naturalOrder()).orElseThrow();
+            var utbetalingdagsatsTidslinje = utbetalinger.stream()
+                .map(utbetaling -> new LocalDateSegment<>(utbetaling.fraOgMed(),
+                    tomEllerNull(maxUtbetalt, utbetaling), utbetaling.sats()))
+                .collect(Collectors.collectingAndThen(Collectors.toList(),
+                    l -> new LocalDateTimeline<>(l, StandardCombinators::max)))
+                .compress();
+            var rettighetsperioderUtenDagsats = rettighetsperioderTidslinje.disjoint(utbetalingdagsatsTidslinje);
+            if (rettighetsperioderUtenDagsats.isEmpty()) {
+                return rettighetsperioderTidslinje.intersection(utbetalingdagsatsTidslinje, StandardCombinators::max);
+            } else {
+                throw new IllegalStateException("Mangler utbetalinger for rettighetsperioder: " + rettighetsperioderUtenDagsats);
+            }
+        }
+    }
+
+    private static LocalDate tomEllerNull(LocalDate max, DagpengerUtbetalingDto utbetaling) {
+        return max.equals(utbetaling.tilOgMed()) ? null : utbetaling.tilOgMed();
+    }
+
+    private record MappedUtbetaling(Integer sats, Integer utbetaltBeløp, Integer sumUtbetalt) implements Comparable<MappedUtbetaling> {
+
+        MappedUtbetaling(DagpengerUtbetalingDto utbetaling) {
+            this(utbetaling.sats(), utbetaling.utbetaltBeløp(), utbetaling.utbetaltBeløp());
+        }
+
+        @Override
+        public int compareTo(MappedUtbetaling o) {
+            var utbetaltDiff = Integer.compare(this.utbetaltBeløp, o.utbetaltBeløp);
+            return utbetaltDiff == 0 ? Integer.compare(this.sats, o.sats) : utbetaltDiff;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            return o instanceof MappedUtbetaling that && sats.equals(that.sats) && utbetaltBeløp.equals(that.utbetaltBeløp);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(sats, utbetaltBeløp);
+        }
+    }
+
+    private static LocalDateTimeline<MappedUtbetaling> mapDatadelingDpsakUtbetaling(List<DagpengerUtbetalingDto> utbetalinger) {
+        var mapped = utbetalinger.stream()
+            .filter(DpsakMapper::virkedagEllerUtbetaling)
+            .map(u -> new LocalDateSegment<>(new LocalDateInterval(u.fraOgMed(), u.tilOgMed()), new MappedUtbetaling(u)))
+            .collect(Collectors.collectingAndThen(Collectors.toList(), l -> new LocalDateTimeline<>(l, StandardCombinators::max)));
+        // Slå sammen dager med lik dagsats og utbetaling. Utvide fredager til søndag pga filter over. Summer sumUtbetalt ved sammenslåing
+        return mapped.compress(LocalDateInterval::abutsWorkdays, MappedUtbetaling::equals, DpsakMapper::slåSammen);
+    }
+
+    private static boolean virkedagEllerUtbetaling(DagpengerUtbetalingDto utbetaling) {
+        return utbetaling.utbetaltBeløp() > 0 || utbetaling.fraOgMed().getDayOfWeek().compareTo(DayOfWeek.SATURDAY) < 0
+            || utbetaling.tilOgMed().getDayOfWeek().compareTo(DayOfWeek.SATURDAY) < 0;
+    }
+
+    private static LocalDateSegment<MappedUtbetaling> slåSammen(LocalDateInterval i,
+                                                                LocalDateSegment<MappedUtbetaling> lhs,
+                                                                LocalDateSegment<MappedUtbetaling> rhs) {
+        return new LocalDateSegment<>(i, new MappedUtbetaling(lhs.getValue().sats(), lhs.getValue().utbetaltBeløp(),
+            lhs.getValue().sumUtbetalt() + rhs.getValue().utbetaltBeløp()));
+    }
+
+}

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapper.java
@@ -13,6 +13,7 @@ import no.nav.fpsak.tidsserie.LocalDateSegment;
 import no.nav.fpsak.tidsserie.LocalDateTimeline;
 import no.nav.fpsak.tidsserie.StandardCombinators;
 
+// Kopiert fra dp-sak
 public class DpsakMapper {
 
     private DpsakMapper() {

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
@@ -23,22 +23,22 @@ import org.slf4j.LoggerFactory;
 // https://navikt.github.io/dp-datadeling/openapi.html
 @ApplicationScoped
 @ScopedRestIntegration(scopeKey = "dagpenger.scope", defaultScope = "api://prod-gcp.teamdagpenger.dp-datadeling/.default/.default")
-public class DpsakKlient {
+public class DpsakRestKlient {
 
-    private static final Logger LOG = LoggerFactory.getLogger(DpsakKlient.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DpsakRestKlient.class);
 
     private URI beregningerEndpoint;
     private URI rettighetsperioderEndpoint;
     private SystemUserOidcRestClient restClient;
 
     @Inject
-    public DpsakKlient(SystemUserOidcRestClient restClient, @KonfigVerdi(value = "dagpengerdatadeling.base.url") URI dagpengerUrl) {
+    public DpsakRestKlient(SystemUserOidcRestClient restClient, @KonfigVerdi(value = "dagpengerdatadeling.base.url") URI dagpengerUrl) {
         beregningerEndpoint = UriBuilder.fromUri(dagpengerUrl).path("/dagpenger/datadeling/v1/beregninger").build();
         rettighetsperioderEndpoint = UriBuilder.fromUri(dagpengerUrl).path("/dagpenger/datadeling/v1/perioder").build();
         this.restClient = restClient;
     }
 
-    public DpsakKlient() {
+    public DpsakRestKlient() {
     }
 
     public Map<Fagsystem, List<DpsakVedtak>> hentDagpenger(PersonIdent personIdent, LocalDate fom, LocalDate tom, Saksnummer sak,

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
@@ -47,13 +47,13 @@ public class DpsakRestKlient {
             var perioder = hentRettighetsperioder(personIdent, fom, tom);
             var utbetalinger = hentUtbetalinger(personIdent, fom, tom);
             var perioderArena = perioder.stream()
-                .filter(periode -> DagpengerRettighetsperioderDto.DagpengerKilde.ARENA.equals(periode.kilde()))
+                .filter(periode -> DagpengerKilde.ARENA.equals(periode.kilde()))
                 .toList();
             var utbetalingerArena = utbetalinger.stream()
                 .filter(u -> DagpengerKilde.ARENA.equals(u.kilde()))
                 .toList();
             var perioderDpsak = perioder.stream()
-                .filter(p -> DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK.equals(p.kilde()))
+                .filter(p -> DagpengerKilde.DP_SAK.equals(p.kilde()))
                 .toList();
             var utbetalingerDpsak = utbetalinger.stream()
                 .filter(u -> DagpengerKilde.DP_SAK.equals(u.kilde()))

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 // https://navikt.github.io/dp-datadeling/openapi.html
 @ApplicationScoped
-@ScopedRestIntegration(scopeKey = "dagpenger.scope", defaultScope = "api://prod-gcp.teamdagpenger.dp-datadeling/.default/.default")
+@ScopedRestIntegration(scopeKey = "dagpengerdatadeling.scope", defaultScope = "api://prod-gcp.teamdagpenger.dp-datadeling/.default")
 public class DpsakRestKlient {
 
     private static final Logger LOG = LoggerFactory.getLogger(DpsakRestKlient.class);
@@ -63,7 +63,7 @@ public class DpsakRestKlient {
                     perioderArena.size(), utbetalingerArena.size(), antallArenaVedtak, antallArenaMeldekort);
             }
             if (!perioderDpsak.isEmpty() || !utbetalingerDpsak.isEmpty()) {
-                LOG.info("DP-DATADELING DPSAK fant {} perioder og {} utbetalinger, ", perioderDpsak.size(), utbetalingerDpsak.size());
+                LOG.info("DP-DATADELING DPSAK fant {} perioder og {} utbetalinger.", perioderDpsak.size(), utbetalingerDpsak.size());
                 LOG.info("Sak {} har nye dagpenger.", sak.getVerdi());
             }
             var dpsakVedtak = DpsakMapper.fullMapping(perioderDpsak, utbetalingerDpsak);

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakRestKlient.java
@@ -47,7 +47,10 @@ public class DpsakRestKlient {
             var perioder = hentRettighetsperioder(personIdent, fom, tom);
             var utbetalinger = hentUtbetalinger(personIdent, fom, tom);
             var perioderArena = perioder.stream()
-                .filter(p -> DagpengerRettighetsperioderDto.DagpengerKilde.ARENA.equals(p.kilde()))
+                .filter(periode -> DagpengerRettighetsperioderDto.DagpengerKilde.ARENA.equals(periode.kilde()))
+                .toList();
+            var utbetalingerArena = utbetalinger.stream()
+                .filter(u -> DagpengerKilde.ARENA.equals(u.kilde()))
                 .toList();
             var perioderDpsak = perioder.stream()
                 .filter(p -> DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK.equals(p.kilde()))
@@ -55,22 +58,18 @@ public class DpsakRestKlient {
             var utbetalingerDpsak = utbetalinger.stream()
                 .filter(u -> DagpengerKilde.DP_SAK.equals(u.kilde()))
                 .toList();
-            var utbetalingerArena = utbetalinger.stream()
-                .filter(u -> DagpengerKilde.ARENA.equals(u.kilde()))
-                .toList();
             if (!perioderArena.isEmpty() || !utbetalingerArena.isEmpty()) {
                 LOG.info("DP-DATADELING ARENA fant {} perioder og {} utbetalinger mot {} vedtak og {} MK fra Arena",
                     perioderArena.size(), utbetalingerArena.size(), antallArenaVedtak, antallArenaMeldekort);
             }
             if (!perioderDpsak.isEmpty() || !utbetalingerDpsak.isEmpty()) {
-                LOG.info("DP-DATADELING DPSAK fant {} perioder og {} utbetalinger. Perioder: {}. Utbetalinger {}",
-                    perioderDpsak.size(), utbetalingerDpsak.size(), perioderDpsak, utbetalingerDpsak);
-                LOG.warn("Merk Dem! Sak {} har nye dagpenger. Kontakt produkteier umiddelbart", sak.getVerdi());
+                LOG.info("DP-DATADELING DPSAK fant {} perioder og {} utbetalinger, ", perioderDpsak.size(), utbetalingerDpsak.size());
+                LOG.info("Sak {} har nye dagpenger.", sak.getVerdi());
             }
             var dpsakVedtak = DpsakMapper.fullMapping(perioderDpsak, utbetalingerDpsak);
             return Map.of(Fagsystem.DPSAK, dpsakVedtak);
         } catch (Exception e) {
-            LOG.info("DP-DATADELING feil ", e);
+            LOG.error("DP-DATADELING feil ", e);
             return Map.of();
         }
     }
@@ -78,20 +77,20 @@ public class DpsakRestKlient {
     public List<DagpengerRettighetsperioderDto.Rettighetsperiode> hentRettighetsperioder(PersonIdent personIdent, LocalDate fom, LocalDate tom) {
         var prequest = new PersonRequest(personIdent.getIdent(), fom, tom);
         try {
-            var result = restClient.post(rettighetsperioderEndpoint, prequest, DagpengerRettighetsperioderDto.class);
-            return result.perioder();
+            var rettighetsperioder = restClient.post(rettighetsperioderEndpoint, prequest, DagpengerRettighetsperioderDto.class);
+            return rettighetsperioder.perioder();
         } catch (UriBuilderException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("Utviklerfeil syntax-exception for hentDagpenger fra dp-sak");
+            throw new IllegalArgumentException("Kall til dp-sak rettighetsperioder feilet", e);
         }
     }
 
     public List<DagpengerUtbetalingDto> hentUtbetalinger(PersonIdent personIdent, LocalDate fom, LocalDate tom) {
         var prequest = new PersonRequest(personIdent.getIdent(), fom, tom);
         try {
-            var result = restClient.post(beregningerEndpoint, prequest, DagpengerUtbetalingDto[].class);
-            return Arrays.stream(result).toList();
+            var utbetalinger = restClient.post(beregningerEndpoint, prequest, DagpengerUtbetalingDto[].class);
+            return Arrays.stream(utbetalinger).toList();
         } catch (UriBuilderException | IllegalArgumentException e) {
-            throw new IllegalArgumentException("Utviklerfeil syntax-exception for hentDagpenger fra dp-sak");
+            throw new IllegalArgumentException("Kall til dp-sak beregninger (utbetalinger) feilet", e);
         }
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakVedtak.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakVedtak.java
@@ -4,8 +4,10 @@ import java.util.List;
 
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 
+// Er konstruert fra dp-datadeling ved å slå sammen perioder med lik dagsats
 public record DpsakVedtak(LocalDateInterval periode, Integer dagsats, List<DpsakUtbetaling> utbetalinger) {
 
-    public record DpsakUtbetaling(LocalDateInterval periode, Integer dagsats, Integer utbetaltBeløp, Integer sumUtbetalt) {}
+    // Dagsats og dagutbetalt er sats og beløp pr dag - som skal være like for perioden. sumUtbetalt er sum av dagutbetalt for perioden
+    public record DpsakUtbetaling(LocalDateInterval periode, Integer dagsats, Integer dagutbetalt, Integer sumUtbetalt) {}
 
 }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakVedtak.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakVedtak.java
@@ -1,0 +1,11 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import java.util.List;
+
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+public record DpsakVedtak(LocalDateInterval periode, Integer dagsats, List<DpsakUtbetaling> utbetalinger) {
+
+    public record DpsakUtbetaling(LocalDateInterval periode, Integer dagsats, Integer utbetaltBeløp, Integer sumUtbetalt) {}
+
+}

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhentingTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/YtelseRegisterInnhentingTest.java
@@ -1,0 +1,197 @@
+package no.nav.k9.abakus.registerdata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.abakus.iaygrunnlag.kodeverk.Fagsystem;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseStatus;
+import no.nav.abakus.iaygrunnlag.kodeverk.YtelseType;
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+import no.nav.k9.abakus.domene.iay.InntektArbeidYtelseAggregatBuilder;
+import no.nav.k9.abakus.domene.iay.Ytelse;
+import no.nav.k9.abakus.domene.iay.YtelseAnvist;
+import no.nav.k9.abakus.registerdata.ytelse.dpsak.DpsakVedtak;
+
+// Tester er generert av nav-pilot
+class YtelseRegisterInnhentingTest {
+
+    private final YtelseRegisterInnhenting ytelseRegisterInnhenting = new YtelseRegisterInnhenting(null, null);
+
+    @Test
+    void skal_oversette_dpsak_vedtak_med_løpende_status() {
+        // Arrange
+        LocalDate idag = LocalDate.now();
+        LocalDate fom = idag.minusMonths(2);
+        LocalDate tom = idag.plusMonths(1);
+
+        var utbetalinger = List.of(
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom, tom),
+                100, // dagsats
+                100, // dagutbetalt
+                5000 // sumUtbetalt
+            )
+        );
+        var vedtak = new DpsakVedtak(new LocalDateInterval(fom, tom), 100, utbetalinger);
+
+        var builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());
+
+        // Act
+        ytelseRegisterInnhenting.oversettDpsakTilYtelse(builder, vedtak);
+
+        // Assert
+        var ytelser = builder.build().getAlleYtelser();
+        assertThat(ytelser).hasSize(1);
+
+        Ytelse ytelse = ytelser.iterator().next();
+        assertThat(ytelse.getRelatertYtelseType()).isEqualTo(YtelseType.DAGPENGER);
+        assertThat(ytelse.getKilde()).isEqualTo(Fagsystem.DPSAK);
+        assertThat(ytelse.getPeriode().getFomDato()).isEqualTo(fom);
+        assertThat(ytelse.getPeriode().getTomDato()).isEqualTo(tom);
+        assertThat(ytelse.getStatus()).isEqualTo(YtelseStatus.LØPENDE);
+
+        assertThat(ytelse.getYtelseAnvist()).hasSize(1);
+        YtelseAnvist anvist = ytelse.getYtelseAnvist().iterator().next();
+        assertThat(anvist.getBeløp().get().getVerdi().intValue()).isEqualTo(5000);
+        assertThat(anvist.getDagsats().get().getVerdi().intValue()).isEqualTo(100);
+        assertThat(anvist.getUtbetalingsgradProsent().get().getVerdi().intValue()).isEqualTo(100);
+    }
+
+    @Test
+    void skal_oversette_dpsak_vedtak_med_avsluttet_status() {
+        // Arrange
+        LocalDate fom = LocalDate.now().minusMonths(3);
+        LocalDate tom = LocalDate.now().minusMonths(1);
+
+        var utbetalinger = List.of(
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom, tom),
+                100,
+                100,
+                5000
+            )
+        );
+        var vedtak = new DpsakVedtak(new LocalDateInterval(fom, tom), 100, utbetalinger);
+
+        var builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());
+
+        // Act
+        ytelseRegisterInnhenting.oversettDpsakTilYtelse(builder, vedtak);
+
+        // Assert
+        Ytelse ytelse = builder.build().getAlleYtelser().iterator().next();
+        assertThat(ytelse.getStatus()).isEqualTo(YtelseStatus.AVSLUTTET);
+        YtelseAnvist anvist = ytelse.getYtelseAnvist().iterator().next();
+        assertThat(anvist.getBeløp().get().getVerdi().intValue()).isEqualTo(5000);
+        assertThat(anvist.getDagsats().get().getVerdi().intValue()).isEqualTo(100);
+        assertThat(anvist.getUtbetalingsgradProsent().get().getVerdi().intValue()).isEqualTo(100);
+    }
+
+    @Test
+    void skal_beregne_utbetalingsgrad_korrekt() {
+        // Arrange
+        LocalDate fom = LocalDate.now().minusMonths(1);
+        LocalDate tom = LocalDate.now();
+
+        var utbetalinger = List.of(
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom, tom),
+                1000, // dagsats
+                600,  // dagutbetalt
+                18000 // sumUtbetalt
+            )
+        );
+        var vedtak = new DpsakVedtak(new LocalDateInterval(fom, tom), 1000, utbetalinger);
+
+        var builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());
+
+        // Act
+        ytelseRegisterInnhenting.oversettDpsakTilYtelse(builder, vedtak);
+
+        // Assert
+        Ytelse ytelse = builder.build().getAlleYtelser().iterator().next();
+        YtelseAnvist anvist = ytelse.getYtelseAnvist().iterator().next();
+
+        // 600 * 100 / 1000 = 60%
+        assertThat(anvist.getBeløp().get().getVerdi().intValue()).isEqualTo(18000);
+        assertThat(anvist.getDagsats().get().getVerdi().intValue()).isEqualTo(1000);
+        assertThat(anvist.getUtbetalingsgradProsent().get().getVerdi().intValue()).isEqualTo(60);
+    }
+
+    @Test
+    void skal_oversette_flere_utbetalinger() {
+        // Arrange
+        LocalDate fom1 = LocalDate.now().minusMonths(2);
+        LocalDate tom1 = LocalDate.now().minusMonths(1).minusDays(15);
+        LocalDate fom2 = LocalDate.now().minusDays(14);
+        LocalDate tom2 = LocalDate.now();
+
+        var utbetalinger = List.of(
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom1, tom1),
+                100,
+                100,
+                2000
+            ),
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom2, tom2),
+                100,
+                80,
+                1600
+            )
+        );
+        var vedtak = new DpsakVedtak(new LocalDateInterval(fom1, tom2), 100, utbetalinger);
+
+        var builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());
+
+        // Act
+        ytelseRegisterInnhenting.oversettDpsakTilYtelse(builder, vedtak);
+
+        // Assert
+        Ytelse ytelse = builder.build().getAlleYtelser().iterator().next();
+        Collection<YtelseAnvist> anvisninger = ytelse.getYtelseAnvist();
+        assertThat(anvisninger).hasSize(2);
+
+        var anvisteList = anvisninger.stream().toList();
+        assertThat(anvisteList.get(0).getBeløp().get().getVerdi().intValue()).isEqualTo(2000);
+        assertThat(anvisteList.get(0).getDagsats().get().getVerdi().intValue()).isEqualTo(100);
+        assertThat(anvisteList.get(0).getUtbetalingsgradProsent().get().getVerdi().intValue()).isEqualTo(100);
+        assertThat(anvisteList.get(1).getBeløp().get().getVerdi().intValue()).isEqualTo(1600);
+        assertThat(anvisteList.get(1).getDagsats().get().getVerdi().intValue()).isEqualTo(100);
+        assertThat(anvisteList.get(1).getUtbetalingsgradProsent().get().getVerdi().intValue()).isEqualTo(80);
+    }
+
+    @Test
+    void skal_sette_vedtaksDagsats() {
+        // Arrange
+        LocalDate fom = LocalDate.now().minusMonths(1);
+        LocalDate tom = LocalDate.now();
+
+        var utbetalinger = List.of(
+            new DpsakVedtak.DpsakUtbetaling(
+                new LocalDateInterval(fom, tom),
+                250,
+                250,
+                5000
+            )
+        );
+        var vedtak = new DpsakVedtak(new LocalDateInterval(fom, tom), 250, utbetalinger);
+
+        var builder = InntektArbeidYtelseAggregatBuilder.AktørYtelseBuilder.oppdatere(Optional.empty());
+
+        // Act
+        ytelseRegisterInnhenting.oversettDpsakTilYtelse(builder, vedtak);
+
+        // Assert
+        Ytelse ytelse = builder.build().getAlleYtelser().iterator().next();
+        assertThat(ytelse.getYtelseGrunnlag().get().getVedtaksDagsats().get().getVerdi()).isEqualTo(new BigDecimal("250"));
+    }
+
+}

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
@@ -37,7 +37,7 @@ class DpsakMapperTest {
         try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase1.json")) {
             assertThat(resource).isNotNull();
             var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);
-            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes()));
+            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
             var vedtak = DpsakMapper.fullMapping(List.of(periode), utbetalinger);
             assertThat(vedtak).hasSize(2);
             var v1 = vedtak.getFirst();
@@ -63,7 +63,7 @@ class DpsakMapperTest {
         try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase2.json")) {
             assertThat(resource).isNotNull();
             var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);
-            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes()));
+            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8));
             var vedtak = DpsakMapper.fullMapping(List.of(periode), utbetalinger);
             assertThat(vedtak).hasSize(2);
             var v1 = vedtak.getFirst();

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 
 import no.nav.fpsak.tidsserie.LocalDateInterval;
 
+// Kopiert fra fp-abakus
 class DpsakMapperTest {
 
     @Test

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
@@ -73,14 +73,14 @@ class DpsakMapperTest {
             assertThat(v1.dagsats()).isEqualTo(1423);
             assertThat(v1.utbetalinger()).hasSize(9);
             assertThat(v1.utbetalinger().getLast().dagsats()).isEqualTo(1423);
-            assertThat(v1.utbetalinger().getLast().utbetaltBeløp()).isEqualTo(1423);
+            assertThat(v1.utbetalinger().getLast().dagutbetalt()).isEqualTo(1423);
             assertThat(v1.utbetalinger().getLast().sumUtbetalt()).isEqualTo(43 * 1423);
             assertThat(v2.periode().getFomDato()).isEqualTo(nyttår);
             assertThat(v2.periode().getTomDato()).isEqualTo(sluttdato);
             assertThat(v2.dagsats()).isEqualTo(1424);
             assertThat(v2.utbetalinger()).hasSize(5);
             assertThat(v2.utbetalinger().getLast().dagsats()).isEqualTo(1424);
-            assertThat(v2.utbetalinger().getLast().utbetaltBeløp()).isEqualTo(1424);
+            assertThat(v2.utbetalinger().getLast().dagutbetalt()).isEqualTo(1424);
             assertThat(v2.utbetalinger().getLast().sumUtbetalt()).isEqualTo(14 * 1424);
         }
     }

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
@@ -19,7 +19,7 @@ class DpsakMapperTest {
     void ingen_utbetalinger() {
         var startdato = LocalDate.of(2025, Month.SEPTEMBER,1);
         var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, null,
-            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+            DagpengerKilde.DP_SAK);
         var vedtak = DpsakMapper.fullMapping(List.of(periode), List.of());
         assertThat(vedtak).hasSize(1);
         var v1 = vedtak.getFirst();
@@ -34,7 +34,7 @@ class DpsakMapperTest {
         var startdato = LocalDate.of(2025, Month.SEPTEMBER,1);
         var nyttår = LocalDate.of(2026, Month.JANUARY,1);
         var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, null,
-            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+            DagpengerKilde.DP_SAK);
         try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase1.json")) {
             assertThat(resource).isNotNull();
             var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);
@@ -60,7 +60,7 @@ class DpsakMapperTest {
         var sluttdato = LocalDate.of(2026, Month.FEBRUARY,4);
         var nyttår = LocalDate.of(2026, Month.JANUARY,1);
         var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, sluttdato,
-            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+            DagpengerKilde.DP_SAK);
         try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase2.json")) {
             assertThat(resource).isNotNull();
             var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);

--- a/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
+++ b/domenetjenester/iay/src/test/java/no/nav/k9/abakus/registerdata/ytelse/dpsak/DpsakMapperTest.java
@@ -1,0 +1,88 @@
+package no.nav.k9.abakus.registerdata.ytelse.dpsak;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+
+import no.nav.k9.felles.integrasjon.rest.DefaultJsonMapper;
+
+import org.junit.jupiter.api.Test;
+
+import no.nav.fpsak.tidsserie.LocalDateInterval;
+
+class DpsakMapperTest {
+
+    @Test
+    void ingen_utbetalinger() {
+        var startdato = LocalDate.of(2025, Month.SEPTEMBER,1);
+        var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, null,
+            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+        var vedtak = DpsakMapper.fullMapping(List.of(periode), List.of());
+        assertThat(vedtak).hasSize(1);
+        var v1 = vedtak.getFirst();
+        assertThat(v1.periode().getFomDato()).isEqualTo(startdato);
+        assertThat(v1.dagsats()).isZero();
+        assertThat(v1.utbetalinger()).isEmpty();
+    }
+
+
+    @Test
+    void testcase1_mapping() throws Exception {
+        var startdato = LocalDate.of(2025, Month.SEPTEMBER,1);
+        var nyttår = LocalDate.of(2026, Month.JANUARY,1);
+        var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, null,
+            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+        try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase1.json")) {
+            assertThat(resource).isNotNull();
+            var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);
+            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes()));
+            var vedtak = DpsakMapper.fullMapping(List.of(periode), utbetalinger);
+            assertThat(vedtak).hasSize(2);
+            var v1 = vedtak.getFirst();
+            var v2 = vedtak.getLast();
+            assertThat(v1.periode().getFomDato()).isEqualTo(startdato);
+            assertThat(v1.periode().getTomDato()).isEqualTo(nyttår.minusDays(1));
+            assertThat(v1.dagsats()).isEqualTo(1423);
+            assertThat(v1.utbetalinger()).hasSize(9);
+            assertThat(v2.periode().getFomDato()).isEqualTo(nyttår);
+            assertThat(v2.periode().getTomDato()).isEqualTo(LocalDateInterval.TIDENES_ENDE);
+            assertThat(v2.dagsats()).isEqualTo(1424);
+            assertThat(v2.utbetalinger()).hasSize(3);
+        }
+    }
+
+    @Test
+    void testcase2_mapping() throws Exception {
+        var startdato = LocalDate.of(2025, Month.AUGUST,26);//2025-08-26, tilOgMedDato=2026-02-04
+        var sluttdato = LocalDate.of(2026, Month.FEBRUARY,4);
+        var nyttår = LocalDate.of(2026, Month.JANUARY,1);
+        var periode = new DagpengerRettighetsperioderDto.Rettighetsperiode(startdato, sluttdato,
+            DagpengerRettighetsperioderDto.DagpengerKilde.DP_SAK);
+        try (var resource = DpsakMapper.class.getResourceAsStream("/dpsak/testcase2.json")) {
+            assertThat(resource).isNotNull();
+            var listObjectMapper = DefaultJsonMapper.MAPPER.readerForListOf(DagpengerUtbetalingDto.class);
+            var utbetalinger = (List<DagpengerUtbetalingDto>) listObjectMapper.readValue(new String(resource.readAllBytes()));
+            var vedtak = DpsakMapper.fullMapping(List.of(periode), utbetalinger);
+            assertThat(vedtak).hasSize(2);
+            var v1 = vedtak.getFirst();
+            var v2 = vedtak.getLast();
+            assertThat(v1.periode().getFomDato()).isEqualTo(startdato);
+            assertThat(v1.periode().getTomDato()).isEqualTo(nyttår.minusDays(1));
+            assertThat(v1.dagsats()).isEqualTo(1423);
+            assertThat(v1.utbetalinger()).hasSize(9);
+            assertThat(v1.utbetalinger().getLast().dagsats()).isEqualTo(1423);
+            assertThat(v1.utbetalinger().getLast().utbetaltBeløp()).isEqualTo(1423);
+            assertThat(v1.utbetalinger().getLast().sumUtbetalt()).isEqualTo(43 * 1423);
+            assertThat(v2.periode().getFomDato()).isEqualTo(nyttår);
+            assertThat(v2.periode().getTomDato()).isEqualTo(sluttdato);
+            assertThat(v2.dagsats()).isEqualTo(1424);
+            assertThat(v2.utbetalinger()).hasSize(5);
+            assertThat(v2.utbetalinger().getLast().dagsats()).isEqualTo(1424);
+            assertThat(v2.utbetalinger().getLast().utbetaltBeløp()).isEqualTo(1424);
+            assertThat(v2.utbetalinger().getLast().sumUtbetalt()).isEqualTo(14 * 1424);
+        }
+    }
+
+}

--- a/domenetjenester/iay/src/test/resources/dpsak/testcase1.json
+++ b/domenetjenester/iay/src/test/resources/dpsak/testcase1.json
@@ -1,0 +1,1402 @@
+[
+  {
+    "fraOgMed": "2025-09-01",
+    "tilOgMed": "2025-09-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 569,
+    "gjenståendeDager": 519
+  },
+  {
+    "fraOgMed": "2025-09-02",
+    "tilOgMed": "2025-09-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 569,
+    "gjenståendeDager": 518
+  },
+  {
+    "fraOgMed": "2025-09-03",
+    "tilOgMed": "2025-09-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 569,
+    "gjenståendeDager": 517
+  },
+  {
+    "fraOgMed": "2025-09-04",
+    "tilOgMed": "2025-09-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 569,
+    "gjenståendeDager": 516
+  },
+  {
+    "fraOgMed": "2025-09-05",
+    "tilOgMed": "2025-09-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 570,
+    "gjenståendeDager": 515
+  },
+  {
+    "fraOgMed": "2025-09-06",
+    "tilOgMed": "2025-09-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 515
+  },
+  {
+    "fraOgMed": "2025-09-07",
+    "tilOgMed": "2025-09-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 515
+  },
+  {
+    "fraOgMed": "2025-09-08",
+    "tilOgMed": "2025-09-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 514
+  },
+  {
+    "fraOgMed": "2025-09-09",
+    "tilOgMed": "2025-09-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 513
+  },
+  {
+    "fraOgMed": "2025-09-10",
+    "tilOgMed": "2025-09-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 512
+  },
+  {
+    "fraOgMed": "2025-09-11",
+    "tilOgMed": "2025-09-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 511
+  },
+  {
+    "fraOgMed": "2025-09-12",
+    "tilOgMed": "2025-09-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 510
+  },
+  {
+    "fraOgMed": "2025-09-13",
+    "tilOgMed": "2025-09-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 510
+  },
+  {
+    "fraOgMed": "2025-09-14",
+    "tilOgMed": "2025-09-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 510
+  },
+  {
+    "fraOgMed": "2025-09-15",
+    "tilOgMed": "2025-09-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 509
+  },
+  {
+    "fraOgMed": "2025-09-16",
+    "tilOgMed": "2025-09-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 508
+  },
+  {
+    "fraOgMed": "2025-09-17",
+    "tilOgMed": "2025-09-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 507
+  },
+  {
+    "fraOgMed": "2025-09-18",
+    "tilOgMed": "2025-09-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1119,
+    "gjenståendeDager": 506
+  },
+  {
+    "fraOgMed": "2025-09-19",
+    "tilOgMed": "2025-09-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1123,
+    "gjenståendeDager": 505
+  },
+  {
+    "fraOgMed": "2025-09-20",
+    "tilOgMed": "2025-09-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 505
+  },
+  {
+    "fraOgMed": "2025-09-21",
+    "tilOgMed": "2025-09-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 505
+  },
+  {
+    "fraOgMed": "2025-09-22",
+    "tilOgMed": "2025-09-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 504
+  },
+  {
+    "fraOgMed": "2025-09-23",
+    "tilOgMed": "2025-09-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 503
+  },
+  {
+    "fraOgMed": "2025-09-24",
+    "tilOgMed": "2025-09-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 502
+  },
+  {
+    "fraOgMed": "2025-09-25",
+    "tilOgMed": "2025-09-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 501
+  },
+  {
+    "fraOgMed": "2025-09-26",
+    "tilOgMed": "2025-09-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 500
+  },
+  {
+    "fraOgMed": "2025-09-27",
+    "tilOgMed": "2025-09-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 500
+  },
+  {
+    "fraOgMed": "2025-09-28",
+    "tilOgMed": "2025-09-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 500
+  },
+  {
+    "fraOgMed": "2025-09-29",
+    "tilOgMed": "2025-09-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 499
+  },
+  {
+    "fraOgMed": "2025-09-30",
+    "tilOgMed": "2025-09-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 498
+  },
+  {
+    "fraOgMed": "2025-10-01",
+    "tilOgMed": "2025-10-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 497
+  },
+  {
+    "fraOgMed": "2025-10-02",
+    "tilOgMed": "2025-10-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 496
+  },
+  {
+    "fraOgMed": "2025-10-03",
+    "tilOgMed": "2025-10-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 495
+  },
+  {
+    "fraOgMed": "2025-10-04",
+    "tilOgMed": "2025-10-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 495
+  },
+  {
+    "fraOgMed": "2025-10-05",
+    "tilOgMed": "2025-10-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 495
+  },
+  {
+    "fraOgMed": "2025-10-06",
+    "tilOgMed": "2025-10-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 494
+  },
+  {
+    "fraOgMed": "2025-10-07",
+    "tilOgMed": "2025-10-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 493
+  },
+  {
+    "fraOgMed": "2025-10-08",
+    "tilOgMed": "2025-10-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 492
+  },
+  {
+    "fraOgMed": "2025-10-09",
+    "tilOgMed": "2025-10-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-10",
+    "tilOgMed": "2025-10-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 490
+  },
+  {
+    "fraOgMed": "2025-10-11",
+    "tilOgMed": "2025-10-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 490
+  },
+  {
+    "fraOgMed": "2025-10-12",
+    "tilOgMed": "2025-10-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 490
+  },
+  {
+    "fraOgMed": "2025-10-13",
+    "tilOgMed": "2025-10-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 489
+  },
+  {
+    "fraOgMed": "2025-10-14",
+    "tilOgMed": "2025-10-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 488
+  },
+  {
+    "fraOgMed": "2025-10-15",
+    "tilOgMed": "2025-10-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-16",
+    "tilOgMed": "2025-10-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-17",
+    "tilOgMed": "2025-10-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-18",
+    "tilOgMed": "2025-10-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-19",
+    "tilOgMed": "2025-10-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-20",
+    "tilOgMed": "2025-10-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 486
+  },
+  {
+    "fraOgMed": "2025-10-21",
+    "tilOgMed": "2025-10-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 485
+  },
+  {
+    "fraOgMed": "2025-10-22",
+    "tilOgMed": "2025-10-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-23",
+    "tilOgMed": "2025-10-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 483
+  },
+  {
+    "fraOgMed": "2025-10-24",
+    "tilOgMed": "2025-10-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 482
+  },
+  {
+    "fraOgMed": "2025-10-25",
+    "tilOgMed": "2025-10-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 482
+  },
+  {
+    "fraOgMed": "2025-10-26",
+    "tilOgMed": "2025-10-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 482
+  },
+  {
+    "fraOgMed": "2025-10-27",
+    "tilOgMed": "2025-10-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 481
+  },
+  {
+    "fraOgMed": "2025-10-28",
+    "tilOgMed": "2025-10-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 480
+  },
+  {
+    "fraOgMed": "2025-10-29",
+    "tilOgMed": "2025-10-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 479
+  },
+  {
+    "fraOgMed": "2025-10-30",
+    "tilOgMed": "2025-10-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 478
+  },
+  {
+    "fraOgMed": "2025-10-31",
+    "tilOgMed": "2025-10-31",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 477
+  },
+  {
+    "fraOgMed": "2025-11-01",
+    "tilOgMed": "2025-11-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 477
+  },
+  {
+    "fraOgMed": "2025-11-02",
+    "tilOgMed": "2025-11-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 477
+  },
+  {
+    "fraOgMed": "2025-11-03",
+    "tilOgMed": "2025-11-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 476
+  },
+  {
+    "fraOgMed": "2025-11-04",
+    "tilOgMed": "2025-11-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 475
+  },
+  {
+    "fraOgMed": "2025-11-05",
+    "tilOgMed": "2025-11-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 474
+  },
+  {
+    "fraOgMed": "2025-11-06",
+    "tilOgMed": "2025-11-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 473
+  },
+  {
+    "fraOgMed": "2025-11-07",
+    "tilOgMed": "2025-11-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 472
+  },
+  {
+    "fraOgMed": "2025-11-08",
+    "tilOgMed": "2025-11-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 472
+  },
+  {
+    "fraOgMed": "2025-11-09",
+    "tilOgMed": "2025-11-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 472
+  },
+  {
+    "fraOgMed": "2025-11-10",
+    "tilOgMed": "2025-11-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 471
+  },
+  {
+    "fraOgMed": "2025-11-11",
+    "tilOgMed": "2025-11-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 470
+  },
+  {
+    "fraOgMed": "2025-11-12",
+    "tilOgMed": "2025-11-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 469
+  },
+  {
+    "fraOgMed": "2025-11-13",
+    "tilOgMed": "2025-11-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 468
+  },
+  {
+    "fraOgMed": "2025-11-14",
+    "tilOgMed": "2025-11-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 467
+  },
+  {
+    "fraOgMed": "2025-11-15",
+    "tilOgMed": "2025-11-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 467
+  },
+  {
+    "fraOgMed": "2025-11-16",
+    "tilOgMed": "2025-11-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 467
+  },
+  {
+    "fraOgMed": "2025-11-17",
+    "tilOgMed": "2025-11-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 466
+  },
+  {
+    "fraOgMed": "2025-11-18",
+    "tilOgMed": "2025-11-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 465
+  },
+  {
+    "fraOgMed": "2025-11-19",
+    "tilOgMed": "2025-11-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 464
+  },
+  {
+    "fraOgMed": "2025-11-20",
+    "tilOgMed": "2025-11-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 463
+  },
+  {
+    "fraOgMed": "2025-11-21",
+    "tilOgMed": "2025-11-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 462
+  },
+  {
+    "fraOgMed": "2025-11-22",
+    "tilOgMed": "2025-11-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 462
+  },
+  {
+    "fraOgMed": "2025-11-23",
+    "tilOgMed": "2025-11-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 462
+  },
+  {
+    "fraOgMed": "2025-11-24",
+    "tilOgMed": "2025-11-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 461
+  },
+  {
+    "fraOgMed": "2025-11-25",
+    "tilOgMed": "2025-11-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 460
+  },
+  {
+    "fraOgMed": "2025-11-26",
+    "tilOgMed": "2025-11-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 460
+  },
+  {
+    "fraOgMed": "2025-11-27",
+    "tilOgMed": "2025-11-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 460
+  },
+  {
+    "fraOgMed": "2025-11-28",
+    "tilOgMed": "2025-11-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-11-29",
+    "tilOgMed": "2025-11-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-11-30",
+    "tilOgMed": "2025-11-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-12-01",
+    "tilOgMed": "2025-12-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 458
+  },
+  {
+    "fraOgMed": "2025-12-02",
+    "tilOgMed": "2025-12-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 457
+  },
+  {
+    "fraOgMed": "2025-12-03",
+    "tilOgMed": "2025-12-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 456
+  },
+  {
+    "fraOgMed": "2025-12-04",
+    "tilOgMed": "2025-12-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 455
+  },
+  {
+    "fraOgMed": "2025-12-05",
+    "tilOgMed": "2025-12-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-06",
+    "tilOgMed": "2025-12-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-07",
+    "tilOgMed": "2025-12-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-08",
+    "tilOgMed": "2025-12-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 453
+  },
+  {
+    "fraOgMed": "2025-12-09",
+    "tilOgMed": "2025-12-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 452
+  },
+  {
+    "fraOgMed": "2025-12-10",
+    "tilOgMed": "2025-12-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 451
+  },
+  {
+    "fraOgMed": "2025-12-11",
+    "tilOgMed": "2025-12-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 450
+  },
+  {
+    "fraOgMed": "2025-12-12",
+    "tilOgMed": "2025-12-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-13",
+    "tilOgMed": "2025-12-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-14",
+    "tilOgMed": "2025-12-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-15",
+    "tilOgMed": "2025-12-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 448
+  },
+  {
+    "fraOgMed": "2025-12-16",
+    "tilOgMed": "2025-12-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 447
+  },
+  {
+    "fraOgMed": "2025-12-17",
+    "tilOgMed": "2025-12-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 446
+  },
+  {
+    "fraOgMed": "2025-12-18",
+    "tilOgMed": "2025-12-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 445
+  },
+  {
+    "fraOgMed": "2025-12-19",
+    "tilOgMed": "2025-12-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-20",
+    "tilOgMed": "2025-12-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-21",
+    "tilOgMed": "2025-12-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-22",
+    "tilOgMed": "2025-12-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 443
+  },
+  {
+    "fraOgMed": "2025-12-23",
+    "tilOgMed": "2025-12-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 442
+  },
+  {
+    "fraOgMed": "2025-12-24",
+    "tilOgMed": "2025-12-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 441
+  },
+  {
+    "fraOgMed": "2025-12-25",
+    "tilOgMed": "2025-12-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 440
+  },
+  {
+    "fraOgMed": "2025-12-26",
+    "tilOgMed": "2025-12-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2025-12-27",
+    "tilOgMed": "2025-12-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2025-12-28",
+    "tilOgMed": "2025-12-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2025-12-29",
+    "tilOgMed": "2025-12-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 438
+  },
+  {
+    "fraOgMed": "2025-12-30",
+    "tilOgMed": "2025-12-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 437
+  },
+  {
+    "fraOgMed": "2025-12-31",
+    "tilOgMed": "2025-12-31",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 436
+  },
+  {
+    "fraOgMed": "2026-01-01",
+    "tilOgMed": "2026-01-01",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 435
+  },
+  {
+    "fraOgMed": "2026-01-02",
+    "tilOgMed": "2026-01-02",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-03",
+    "tilOgMed": "2026-01-03",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-04",
+    "tilOgMed": "2026-01-04",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-05",
+    "tilOgMed": "2026-01-05",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 433
+  },
+  {
+    "fraOgMed": "2026-01-06",
+    "tilOgMed": "2026-01-06",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 432
+  },
+  {
+    "fraOgMed": "2026-01-07",
+    "tilOgMed": "2026-01-07",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 431
+  },
+  {
+    "fraOgMed": "2026-01-08",
+    "tilOgMed": "2026-01-08",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 430
+  },
+  {
+    "fraOgMed": "2026-01-09",
+    "tilOgMed": "2026-01-09",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 429
+  },
+  {
+    "fraOgMed": "2026-01-10",
+    "tilOgMed": "2026-01-10",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 429
+  },
+  {
+    "fraOgMed": "2026-01-11",
+    "tilOgMed": "2026-01-11",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 429
+  },
+  {
+    "fraOgMed": "2026-01-12",
+    "tilOgMed": "2026-01-12",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 428
+  },
+  {
+    "fraOgMed": "2026-01-13",
+    "tilOgMed": "2026-01-13",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 427
+  },
+  {
+    "fraOgMed": "2026-01-14",
+    "tilOgMed": "2026-01-14",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 426
+  },
+  {
+    "fraOgMed": "2026-01-15",
+    "tilOgMed": "2026-01-15",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 425
+  },
+  {
+    "fraOgMed": "2026-01-16",
+    "tilOgMed": "2026-01-16",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 424
+  },
+  {
+    "fraOgMed": "2026-01-17",
+    "tilOgMed": "2026-01-17",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 424
+  },
+  {
+    "fraOgMed": "2026-01-18",
+    "tilOgMed": "2026-01-18",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 424
+  },
+  {
+    "fraOgMed": "2026-01-19",
+    "tilOgMed": "2026-01-19",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 423
+  },
+  {
+    "fraOgMed": "2026-01-20",
+    "tilOgMed": "2026-01-20",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 422
+  },
+  {
+    "fraOgMed": "2026-01-21",
+    "tilOgMed": "2026-01-21",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 421
+  },
+  {
+    "fraOgMed": "2026-01-22",
+    "tilOgMed": "2026-01-22",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 420
+  },
+  {
+    "fraOgMed": "2026-01-23",
+    "tilOgMed": "2026-01-23",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 419
+  },
+  {
+    "fraOgMed": "2026-01-24",
+    "tilOgMed": "2026-01-24",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 419
+  },
+  {
+    "fraOgMed": "2026-01-25",
+    "tilOgMed": "2026-01-25",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 419
+  },
+  {
+    "fraOgMed": "2026-01-26",
+    "tilOgMed": "2026-01-26",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 418
+  },
+  {
+    "fraOgMed": "2026-01-27",
+    "tilOgMed": "2026-01-27",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 417
+  },
+  {
+    "fraOgMed": "2026-01-28",
+    "tilOgMed": "2026-01-28",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 416
+  },
+  {
+    "fraOgMed": "2026-01-29",
+    "tilOgMed": "2026-01-29",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 415
+  },
+  {
+    "fraOgMed": "2026-01-30",
+    "tilOgMed": "2026-01-30",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 414
+  },
+  {
+    "fraOgMed": "2026-01-31",
+    "tilOgMed": "2026-01-31",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 414
+  },
+  {
+    "fraOgMed": "2026-02-01",
+    "tilOgMed": "2026-02-01",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 414
+  },
+  {
+    "fraOgMed": "2026-02-02",
+    "tilOgMed": "2026-02-02",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 413
+  },
+  {
+    "fraOgMed": "2026-02-03",
+    "tilOgMed": "2026-02-03",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 412
+  },
+  {
+    "fraOgMed": "2026-02-04",
+    "tilOgMed": "2026-02-04",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 411
+  },
+  {
+    "fraOgMed": "2026-02-05",
+    "tilOgMed": "2026-02-05",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 410
+  },
+  {
+    "fraOgMed": "2026-02-06",
+    "tilOgMed": "2026-02-06",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 409
+  },
+  {
+    "fraOgMed": "2026-02-07",
+    "tilOgMed": "2026-02-07",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 409
+  },
+  {
+    "fraOgMed": "2026-02-08",
+    "tilOgMed": "2026-02-08",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 409
+  },
+  {
+    "fraOgMed": "2026-02-09",
+    "tilOgMed": "2026-02-09",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 408
+  },
+  {
+    "fraOgMed": "2026-02-10",
+    "tilOgMed": "2026-02-10",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 407
+  },
+  {
+    "fraOgMed": "2026-02-11",
+    "tilOgMed": "2026-02-11",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 406
+  },
+  {
+    "fraOgMed": "2026-02-12",
+    "tilOgMed": "2026-02-12",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 405
+  },
+  {
+    "fraOgMed": "2026-02-13",
+    "tilOgMed": "2026-02-13",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 404
+  },
+  {
+    "fraOgMed": "2026-02-14",
+    "tilOgMed": "2026-02-14",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 404
+  },
+  {
+    "fraOgMed": "2026-02-15",
+    "tilOgMed": "2026-02-15",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 404
+  },
+  {
+    "fraOgMed": "2026-02-16",
+    "tilOgMed": "2026-02-16",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 403
+  },
+  {
+    "fraOgMed": "2026-02-17",
+    "tilOgMed": "2026-02-17",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 402
+  },
+  {
+    "fraOgMed": "2026-02-18",
+    "tilOgMed": "2026-02-18",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 401
+  },
+  {
+    "fraOgMed": "2026-02-19",
+    "tilOgMed": "2026-02-19",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 968,
+    "gjenståendeDager": 400
+  },
+  {
+    "fraOgMed": "2026-02-20",
+    "tilOgMed": "2026-02-20",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 971,
+    "gjenståendeDager": 399
+  },
+  {
+    "fraOgMed": "2026-02-21",
+    "tilOgMed": "2026-02-21",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 399
+  },
+  {
+    "fraOgMed": "2026-02-22",
+    "tilOgMed": "2026-02-22",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 399
+  }
+]

--- a/domenetjenester/iay/src/test/resources/dpsak/testcase2.json
+++ b/domenetjenester/iay/src/test/resources/dpsak/testcase2.json
@@ -1,0 +1,1306 @@
+[
+  {
+    "fraOgMed": "2025-08-26",
+    "tilOgMed": "2025-08-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 519
+  },
+  {
+    "fraOgMed": "2025-08-27",
+    "tilOgMed": "2025-08-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 518
+  },
+  {
+    "fraOgMed": "2025-08-28",
+    "tilOgMed": "2025-08-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 517
+  },
+  {
+    "fraOgMed": "2025-08-29",
+    "tilOgMed": "2025-08-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 516
+  },
+  {
+    "fraOgMed": "2025-08-30",
+    "tilOgMed": "2025-08-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 516
+  },
+  {
+    "fraOgMed": "2025-08-31",
+    "tilOgMed": "2025-08-31",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 516
+  },
+  {
+    "fraOgMed": "2025-09-01",
+    "tilOgMed": "2025-09-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 515
+  },
+  {
+    "fraOgMed": "2025-09-02",
+    "tilOgMed": "2025-09-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 514
+  },
+  {
+    "fraOgMed": "2025-09-03",
+    "tilOgMed": "2025-09-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 513
+  },
+  {
+    "fraOgMed": "2025-09-04",
+    "tilOgMed": "2025-09-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 948,
+    "gjenståendeDager": 512
+  },
+  {
+    "fraOgMed": "2025-09-05",
+    "tilOgMed": "2025-09-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 951,
+    "gjenståendeDager": 511
+  },
+  {
+    "fraOgMed": "2025-09-06",
+    "tilOgMed": "2025-09-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 511
+  },
+  {
+    "fraOgMed": "2025-09-07",
+    "tilOgMed": "2025-09-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 511
+  },
+  {
+    "fraOgMed": "2025-09-08",
+    "tilOgMed": "2025-09-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 510
+  },
+  {
+    "fraOgMed": "2025-09-09",
+    "tilOgMed": "2025-09-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 509
+  },
+  {
+    "fraOgMed": "2025-09-10",
+    "tilOgMed": "2025-09-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 508
+  },
+  {
+    "fraOgMed": "2025-09-11",
+    "tilOgMed": "2025-09-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 507
+  },
+  {
+    "fraOgMed": "2025-09-12",
+    "tilOgMed": "2025-09-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 506
+  },
+  {
+    "fraOgMed": "2025-09-13",
+    "tilOgMed": "2025-09-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 506
+  },
+  {
+    "fraOgMed": "2025-09-14",
+    "tilOgMed": "2025-09-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 506
+  },
+  {
+    "fraOgMed": "2025-09-15",
+    "tilOgMed": "2025-09-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 505
+  },
+  {
+    "fraOgMed": "2025-09-16",
+    "tilOgMed": "2025-09-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 504
+  },
+  {
+    "fraOgMed": "2025-09-17",
+    "tilOgMed": "2025-09-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 503
+  },
+  {
+    "fraOgMed": "2025-09-18",
+    "tilOgMed": "2025-09-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1261,
+    "gjenståendeDager": 502
+  },
+  {
+    "fraOgMed": "2025-09-19",
+    "tilOgMed": "2025-09-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1268,
+    "gjenståendeDager": 501
+  },
+  {
+    "fraOgMed": "2025-09-20",
+    "tilOgMed": "2025-09-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 501
+  },
+  {
+    "fraOgMed": "2025-09-21",
+    "tilOgMed": "2025-09-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 501
+  },
+  {
+    "fraOgMed": "2025-09-22",
+    "tilOgMed": "2025-09-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 500
+  },
+  {
+    "fraOgMed": "2025-09-23",
+    "tilOgMed": "2025-09-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 499
+  },
+  {
+    "fraOgMed": "2025-09-24",
+    "tilOgMed": "2025-09-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 498
+  },
+  {
+    "fraOgMed": "2025-09-25",
+    "tilOgMed": "2025-09-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 497
+  },
+  {
+    "fraOgMed": "2025-09-26",
+    "tilOgMed": "2025-09-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 496
+  },
+  {
+    "fraOgMed": "2025-09-27",
+    "tilOgMed": "2025-09-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 496
+  },
+  {
+    "fraOgMed": "2025-09-28",
+    "tilOgMed": "2025-09-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 496
+  },
+  {
+    "fraOgMed": "2025-09-29",
+    "tilOgMed": "2025-09-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 495
+  },
+  {
+    "fraOgMed": "2025-09-30",
+    "tilOgMed": "2025-09-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 494
+  },
+  {
+    "fraOgMed": "2025-10-01",
+    "tilOgMed": "2025-10-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 493
+  },
+  {
+    "fraOgMed": "2025-10-02",
+    "tilOgMed": "2025-10-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 492
+  },
+  {
+    "fraOgMed": "2025-10-03",
+    "tilOgMed": "2025-10-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-04",
+    "tilOgMed": "2025-10-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-05",
+    "tilOgMed": "2025-10-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-06",
+    "tilOgMed": "2025-10-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-07",
+    "tilOgMed": "2025-10-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-08",
+    "tilOgMed": "2025-10-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 491
+  },
+  {
+    "fraOgMed": "2025-10-09",
+    "tilOgMed": "2025-10-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 490
+  },
+  {
+    "fraOgMed": "2025-10-10",
+    "tilOgMed": "2025-10-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 489
+  },
+  {
+    "fraOgMed": "2025-10-11",
+    "tilOgMed": "2025-10-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 489
+  },
+  {
+    "fraOgMed": "2025-10-12",
+    "tilOgMed": "2025-10-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 489
+  },
+  {
+    "fraOgMed": "2025-10-13",
+    "tilOgMed": "2025-10-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 488
+  },
+  {
+    "fraOgMed": "2025-10-14",
+    "tilOgMed": "2025-10-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 487
+  },
+  {
+    "fraOgMed": "2025-10-15",
+    "tilOgMed": "2025-10-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 486
+  },
+  {
+    "fraOgMed": "2025-10-16",
+    "tilOgMed": "2025-10-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 485
+  },
+  {
+    "fraOgMed": "2025-10-17",
+    "tilOgMed": "2025-10-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-18",
+    "tilOgMed": "2025-10-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-19",
+    "tilOgMed": "2025-10-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-20",
+    "tilOgMed": "2025-10-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-21",
+    "tilOgMed": "2025-10-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-22",
+    "tilOgMed": "2025-10-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-23",
+    "tilOgMed": "2025-10-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-24",
+    "tilOgMed": "2025-10-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-25",
+    "tilOgMed": "2025-10-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-26",
+    "tilOgMed": "2025-10-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-27",
+    "tilOgMed": "2025-10-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-28",
+    "tilOgMed": "2025-10-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-29",
+    "tilOgMed": "2025-10-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-30",
+    "tilOgMed": "2025-10-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-10-31",
+    "tilOgMed": "2025-10-31",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-11-01",
+    "tilOgMed": "2025-11-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-11-02",
+    "tilOgMed": "2025-11-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 484
+  },
+  {
+    "fraOgMed": "2025-11-03",
+    "tilOgMed": "2025-11-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 483
+  },
+  {
+    "fraOgMed": "2025-11-04",
+    "tilOgMed": "2025-11-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 482
+  },
+  {
+    "fraOgMed": "2025-11-05",
+    "tilOgMed": "2025-11-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 481
+  },
+  {
+    "fraOgMed": "2025-11-06",
+    "tilOgMed": "2025-11-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 480
+  },
+  {
+    "fraOgMed": "2025-11-07",
+    "tilOgMed": "2025-11-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 479
+  },
+  {
+    "fraOgMed": "2025-11-08",
+    "tilOgMed": "2025-11-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 479
+  },
+  {
+    "fraOgMed": "2025-11-09",
+    "tilOgMed": "2025-11-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 479
+  },
+  {
+    "fraOgMed": "2025-11-10",
+    "tilOgMed": "2025-11-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 478
+  },
+  {
+    "fraOgMed": "2025-11-11",
+    "tilOgMed": "2025-11-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 477
+  },
+  {
+    "fraOgMed": "2025-11-12",
+    "tilOgMed": "2025-11-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 476
+  },
+  {
+    "fraOgMed": "2025-11-13",
+    "tilOgMed": "2025-11-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 475
+  },
+  {
+    "fraOgMed": "2025-11-14",
+    "tilOgMed": "2025-11-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 474
+  },
+  {
+    "fraOgMed": "2025-11-15",
+    "tilOgMed": "2025-11-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 474
+  },
+  {
+    "fraOgMed": "2025-11-16",
+    "tilOgMed": "2025-11-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 474
+  },
+  {
+    "fraOgMed": "2025-11-17",
+    "tilOgMed": "2025-11-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 473
+  },
+  {
+    "fraOgMed": "2025-11-18",
+    "tilOgMed": "2025-11-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 472
+  },
+  {
+    "fraOgMed": "2025-11-19",
+    "tilOgMed": "2025-11-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 471
+  },
+  {
+    "fraOgMed": "2025-11-20",
+    "tilOgMed": "2025-11-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 470
+  },
+  {
+    "fraOgMed": "2025-11-21",
+    "tilOgMed": "2025-11-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 469
+  },
+  {
+    "fraOgMed": "2025-11-22",
+    "tilOgMed": "2025-11-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 469
+  },
+  {
+    "fraOgMed": "2025-11-23",
+    "tilOgMed": "2025-11-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 469
+  },
+  {
+    "fraOgMed": "2025-11-24",
+    "tilOgMed": "2025-11-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 468
+  },
+  {
+    "fraOgMed": "2025-11-25",
+    "tilOgMed": "2025-11-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 467
+  },
+  {
+    "fraOgMed": "2025-11-26",
+    "tilOgMed": "2025-11-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 466
+  },
+  {
+    "fraOgMed": "2025-11-27",
+    "tilOgMed": "2025-11-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 465
+  },
+  {
+    "fraOgMed": "2025-11-28",
+    "tilOgMed": "2025-11-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 464
+  },
+  {
+    "fraOgMed": "2025-11-29",
+    "tilOgMed": "2025-11-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 464
+  },
+  {
+    "fraOgMed": "2025-11-30",
+    "tilOgMed": "2025-11-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 464
+  },
+  {
+    "fraOgMed": "2025-12-01",
+    "tilOgMed": "2025-12-01",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 463
+  },
+  {
+    "fraOgMed": "2025-12-02",
+    "tilOgMed": "2025-12-02",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 462
+  },
+  {
+    "fraOgMed": "2025-12-03",
+    "tilOgMed": "2025-12-03",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 461
+  },
+  {
+    "fraOgMed": "2025-12-04",
+    "tilOgMed": "2025-12-04",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 460
+  },
+  {
+    "fraOgMed": "2025-12-05",
+    "tilOgMed": "2025-12-05",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-12-06",
+    "tilOgMed": "2025-12-06",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-12-07",
+    "tilOgMed": "2025-12-07",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 459
+  },
+  {
+    "fraOgMed": "2025-12-08",
+    "tilOgMed": "2025-12-08",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 458
+  },
+  {
+    "fraOgMed": "2025-12-09",
+    "tilOgMed": "2025-12-09",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 457
+  },
+  {
+    "fraOgMed": "2025-12-10",
+    "tilOgMed": "2025-12-10",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 456
+  },
+  {
+    "fraOgMed": "2025-12-11",
+    "tilOgMed": "2025-12-11",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 455
+  },
+  {
+    "fraOgMed": "2025-12-12",
+    "tilOgMed": "2025-12-12",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-13",
+    "tilOgMed": "2025-12-13",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-14",
+    "tilOgMed": "2025-12-14",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 454
+  },
+  {
+    "fraOgMed": "2025-12-15",
+    "tilOgMed": "2025-12-15",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 453
+  },
+  {
+    "fraOgMed": "2025-12-16",
+    "tilOgMed": "2025-12-16",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 452
+  },
+  {
+    "fraOgMed": "2025-12-17",
+    "tilOgMed": "2025-12-17",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 451
+  },
+  {
+    "fraOgMed": "2025-12-18",
+    "tilOgMed": "2025-12-18",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 450
+  },
+  {
+    "fraOgMed": "2025-12-19",
+    "tilOgMed": "2025-12-19",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-20",
+    "tilOgMed": "2025-12-20",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-21",
+    "tilOgMed": "2025-12-21",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 449
+  },
+  {
+    "fraOgMed": "2025-12-22",
+    "tilOgMed": "2025-12-22",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 448
+  },
+  {
+    "fraOgMed": "2025-12-23",
+    "tilOgMed": "2025-12-23",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 447
+  },
+  {
+    "fraOgMed": "2025-12-24",
+    "tilOgMed": "2025-12-24",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 446
+  },
+  {
+    "fraOgMed": "2025-12-25",
+    "tilOgMed": "2025-12-25",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 445
+  },
+  {
+    "fraOgMed": "2025-12-26",
+    "tilOgMed": "2025-12-26",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-27",
+    "tilOgMed": "2025-12-27",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-28",
+    "tilOgMed": "2025-12-28",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 444
+  },
+  {
+    "fraOgMed": "2025-12-29",
+    "tilOgMed": "2025-12-29",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 443
+  },
+  {
+    "fraOgMed": "2025-12-30",
+    "tilOgMed": "2025-12-30",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 442
+  },
+  {
+    "fraOgMed": "2025-12-31",
+    "tilOgMed": "2025-12-31",
+    "kilde": "DP_SAK",
+    "sats": 1423,
+    "utbetaltBeløp": 1423,
+    "gjenståendeDager": 441
+  },
+  {
+    "fraOgMed": "2026-01-01",
+    "tilOgMed": "2026-01-01",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 440
+  },
+  {
+    "fraOgMed": "2026-01-02",
+    "tilOgMed": "2026-01-02",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2026-01-03",
+    "tilOgMed": "2026-01-03",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2026-01-04",
+    "tilOgMed": "2026-01-04",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 439
+  },
+  {
+    "fraOgMed": "2026-01-05",
+    "tilOgMed": "2026-01-05",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 438
+  },
+  {
+    "fraOgMed": "2026-01-06",
+    "tilOgMed": "2026-01-06",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 437
+  },
+  {
+    "fraOgMed": "2026-01-07",
+    "tilOgMed": "2026-01-07",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 436
+  },
+  {
+    "fraOgMed": "2026-01-08",
+    "tilOgMed": "2026-01-08",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 435
+  },
+  {
+    "fraOgMed": "2026-01-09",
+    "tilOgMed": "2026-01-09",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-10",
+    "tilOgMed": "2026-01-10",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-11",
+    "tilOgMed": "2026-01-11",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 434
+  },
+  {
+    "fraOgMed": "2026-01-12",
+    "tilOgMed": "2026-01-12",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 433
+  },
+  {
+    "fraOgMed": "2026-01-13",
+    "tilOgMed": "2026-01-13",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 433
+  },
+  {
+    "fraOgMed": "2026-01-14",
+    "tilOgMed": "2026-01-14",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 432
+  },
+  {
+    "fraOgMed": "2026-01-15",
+    "tilOgMed": "2026-01-15",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 432
+  },
+  {
+    "fraOgMed": "2026-01-16",
+    "tilOgMed": "2026-01-16",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 431
+  },
+  {
+    "fraOgMed": "2026-01-17",
+    "tilOgMed": "2026-01-17",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 431
+  },
+  {
+    "fraOgMed": "2026-01-18",
+    "tilOgMed": "2026-01-18",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 431
+  },
+  {
+    "fraOgMed": "2026-01-19",
+    "tilOgMed": "2026-01-19",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 430
+  },
+  {
+    "fraOgMed": "2026-01-20",
+    "tilOgMed": "2026-01-20",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 429
+  },
+  {
+    "fraOgMed": "2026-01-21",
+    "tilOgMed": "2026-01-21",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 428
+  },
+  {
+    "fraOgMed": "2026-01-22",
+    "tilOgMed": "2026-01-22",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 427
+  },
+  {
+    "fraOgMed": "2026-01-23",
+    "tilOgMed": "2026-01-23",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 426
+  },
+  {
+    "fraOgMed": "2026-01-24",
+    "tilOgMed": "2026-01-24",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 426
+  },
+  {
+    "fraOgMed": "2026-01-25",
+    "tilOgMed": "2026-01-25",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 426
+  },
+  {
+    "fraOgMed": "2026-01-26",
+    "tilOgMed": "2026-01-26",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 425
+  },
+  {
+    "fraOgMed": "2026-01-27",
+    "tilOgMed": "2026-01-27",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 424
+  },
+  {
+    "fraOgMed": "2026-01-28",
+    "tilOgMed": "2026-01-28",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 423
+  },
+  {
+    "fraOgMed": "2026-01-29",
+    "tilOgMed": "2026-01-29",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 422
+  },
+  {
+    "fraOgMed": "2026-01-30",
+    "tilOgMed": "2026-01-30",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 421
+  },
+  {
+    "fraOgMed": "2026-01-31",
+    "tilOgMed": "2026-01-31",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 421
+  },
+  {
+    "fraOgMed": "2026-02-01",
+    "tilOgMed": "2026-02-01",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 0,
+    "gjenståendeDager": 421
+  },
+  {
+    "fraOgMed": "2026-02-02",
+    "tilOgMed": "2026-02-02",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 420
+  },
+  {
+    "fraOgMed": "2026-02-03",
+    "tilOgMed": "2026-02-03",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 419
+  },
+  {
+    "fraOgMed": "2026-02-04",
+    "tilOgMed": "2026-02-04",
+    "kilde": "DP_SAK",
+    "sats": 1424,
+    "utbetaltBeløp": 1424,
+    "gjenståendeDager": 418
+  }
+]

--- a/web/app-vtp.properties
+++ b/web/app-vtp.properties
@@ -58,6 +58,9 @@ fpabakus.it.ps.scope=testscope
 k9sak.scope=testscope
 ungsak.scope=testscope
 
+dagpengerdatadeling.base.url=http://localhost:8060/rest
+dagpengerdatadeling.scope=testscope
+
 organisasjon.rs.url=https://localhost:8063/rest/ereg/api/v1/organisasjon
 
 # Database
@@ -66,5 +69,5 @@ defaultDS.url=jdbc:postgresql://localhost:5432/k9abakus?reWriteBatchedInserts=tr
 
 fpwsproxy.override.url=http://vtp:8060/rest/api/fpwsproxy
 
-kelvin.url=http://localhost:8060/rest/kelvin
 kelvin.scope=testscope
+kelvin.url=http://localhost:8060/rest/kelvin

--- a/web/src/test/java/no/nav/k9/abakus/web/jetty/JettyDevKonfigurasjon.java
+++ b/web/src/test/java/no/nav/k9/abakus/web/jetty/JettyDevKonfigurasjon.java
@@ -1,7 +1,5 @@
 package no.nav.k9.abakus.web.jetty;
 
-import no.nav.k9.abakus.web.jetty.JettyWebKonfigurasjon;
-
 public class JettyDevKonfigurasjon extends JettyWebKonfigurasjon {
     private static final int SSL_SERVER_PORT = 8915;
     private static int DEFAULT_DEV_SERVER_PORT = 8015;


### PR DESCRIPTION
### Behov / Bakgrunn
Flere og flere dagpengesaker behandles i dp-sak, så vi har behov for å hente data fra dette fagsystemet for å ha komplette data for søkeres dagpenger.

### Løsning
Henter data fra dp-sak, Dagengers nye fagsystem.

Det meste av dette er bare kopiert fra fp-abakus.

### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
