### PR TITLE
Chore: Unngår warnings i loggen: "HV000271: Using `@Valid` on a conta…

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/iay/tjeneste/GrunnlagRestTjeneste.java
@@ -490,7 +490,7 @@ public class GrunnlagRestTjeneste {
                                          @JsonProperty(value = "gammelReferanse", required = true) @Valid @NotNull UUID gammelReferanse,
                                          @JsonProperty(value = "ytelseType", required = true) @Valid @NotNull no.nav.abakus.iaygrunnlag.kodeverk.YtelseType ytelseType,
                                          @JsonProperty(value = "aktør", required = true) @NotNull @Valid PersonIdent aktør,
-                                         @JsonProperty(value = "dataset", required = false) @Valid Set<Dataset> dataset) {
+                                         @JsonProperty(value = "dataset") Set<@Valid Dataset> dataset) {
 
             super(saksnummer, nyReferanse, gammelReferanse, ytelseType, aktør, dataset == null ? EnumSet.allOf(Dataset.class) : dataset);
         }

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/tjeneste/RegisterdataRestTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/tjeneste/RegisterdataRestTjeneste.java
@@ -137,7 +137,7 @@ public class RegisterdataRestTjeneste {
                                           @JsonProperty(value = "ytelseType", required = true) @Valid @NotNull YtelseType ytelseType,
                                           @JsonProperty(value = "opplysningsperiode", required = true) @NotNull @Valid Periode opplysningsperiode,
                                           @JsonProperty(value = "aktør", required = true) @NotNull @Valid PersonIdent aktør,
-                                          @JsonProperty(value = "elementer", required = true) @NotNull @Valid Set<RegisterdataType> elementer) {
+                                          @JsonProperty(value = "elementer", required = true) @NotNull Set<@Valid RegisterdataType> elementer) {
             super(saksnummer, referanse, ytelseType, opplysningsperiode, aktør, elementer);
         }
 

--- a/kontrakt-vedtak/src/main/java/no/nav/abakus/vedtak/ytelse/v1/YtelseV1.java
+++ b/kontrakt-vedtak/src/main/java/no/nav/abakus/vedtak/ytelse/v1/YtelseV1.java
@@ -60,9 +60,8 @@ public class YtelseV1 extends Ytelse {
     private String tilleggsopplysninger;
 
     @NotNull
-    @Valid
     @JsonProperty("anvist")
-    private List<Anvisning> anvist = new ArrayList<>();
+    private List<@Valid Anvisning> anvist = new ArrayList<>();
 
     public YtelseV1() {
     }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/arbeidsforhold/v1/ArbeidsforholdDto.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/arbeidsforhold/v1/ArbeidsforholdDto.java
@@ -35,8 +35,7 @@ public class ArbeidsforholdDto {
     private ArbeidsforholdRefDto arbeidsforholdId;
 
     @JsonProperty("ansettelsePerioder")
-    @Valid
-    private List<Periode> ansettelsesperiode;
+    private List<@Valid Periode> ansettelsesperiode;
 
     protected ArbeidsforholdDto() {
     }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/oppgittopptjening/v1/OppgitteOpptjeningerDto.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/oppgittopptjening/v1/OppgitteOpptjeningerDto.java
@@ -19,8 +19,7 @@ public class OppgitteOpptjeningerDto {
 
     @JsonProperty(value = "oppgitteOpptjeninger", required = true)
     @NotNull
-    @Valid
-    private List<OppgittOpptjeningDto> oppgitteOpptjeninger;
+    private List<@Valid OppgittOpptjeningDto> oppgitteOpptjeninger;
 
     public OppgitteOpptjeningerDto() {
         // default ctor

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/InnhentRegisterdataRequest.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/InnhentRegisterdataRequest.java
@@ -104,7 +104,7 @@ public class InnhentRegisterdataRequest {
                                       @JsonProperty(value = "ytelseType", required = true) @NotNull YtelseType ytelseType,
                                       @JsonProperty(value = "opplysningsperiode", required = true) @NotNull @Valid Periode opplysningsperiode,
                                       @JsonProperty(value = "aktør", required = true) @NotNull @Valid PersonIdent aktør,
-                                      @JsonProperty(value = "elementer", required = true) @NotNull @Valid Set<RegisterdataType> elementer) {
+                                      @JsonProperty(value = "elementer", required = true) @NotNull Set<@Valid RegisterdataType> elementer) {
         this(saksnummer, referanse, ytelseType, opplysningsperiode, aktør);
         this.elementer = elementer;
     }

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/KopierGrunnlagRequest.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/request/KopierGrunnlagRequest.java
@@ -73,7 +73,7 @@ public class KopierGrunnlagRequest {
                                  @JsonProperty(value = "gammelReferanse", required = true) @Valid @NotNull UUID gammelReferanse,
                                  @JsonProperty(value = "ytelseType", required = true) @NotNull YtelseType ytelseType,
                                  @JsonProperty(value = "aktør", required = true) @NotNull @Valid PersonIdent aktør,
-                                 @JsonProperty(value = "dataset", required = true) @NotNull @Valid Set<Dataset> dataset) {
+                                 @JsonProperty(value = "dataset", required = true) @NotNull Set<@Valid Dataset> dataset) {
         this.saksnummer = saksnummer;
         this.nyReferanse = nyReferanse;
         this.gammelReferanse = gammelReferanse;

--- a/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/v1/InntektArbeidYtelseGrunnlagSakSnapshotDto.java
+++ b/kontrakt/src/main/java/no/nav/abakus/iaygrunnlag/v1/InntektArbeidYtelseGrunnlagSakSnapshotDto.java
@@ -59,8 +59,7 @@ public class InntektArbeidYtelseGrunnlagSakSnapshotDto {
      * </ul>
      */
     @JsonProperty(value = "grunnlag", required = true)
-    @Valid
-    private List<Konvolutt> grunnlag = new ArrayList<>();
+    private List<@Valid Konvolutt> grunnlag = new ArrayList<>();
 
     @JsonProperty(value = "snapshotTidspunkt", required = true)
     @Valid


### PR DESCRIPTION
…iner (java.util.List) is deprecated. You should apply the annotation on the type argument(s)."

### Behov / Bakgrunn
Trenger å kunne følge med på loggene i Abakus når nye integrasjoner prodsettes, men det blir uoversiktlig med en masse WARN-linjer med ""HV000271: Using @Valid on a container (java.util.List) is deprecated. You should apply the annotation on the type argument(s)."


### Løsning
Flytte @Valid til typen


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
