### PR TITLE
Chore: lar være å logge ut meldekort og andre sensitive data

### DIFF
--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -62,7 +62,7 @@ public class InnhentingSamletTjeneste {
                                     FpwsproxyKlient fpwsproxyKlient,
                                     KelvinRestKlient kelvinRestKlient,
                                     DpsakRestKlient dpsakRestKlient
-                                    ) {
+    ) {
 
         this.arbeidsforholdTjeneste = arbeidsforholdTjeneste;
         this.inntektTjeneste = inntektTjeneste;
@@ -166,23 +166,19 @@ public class InnhentingSamletTjeneste {
             var kelvinMK = kelvin.stream().map(MeldekortUtbetalingsgrunnlagSak::getMeldekortene).flatMap(Collection::stream).collect(Collectors.toSet());
             var vAIkkeK = arena.stream().filter(a -> kelvin.stream().noneMatch(a::likeNokVedtak))
                 .map(MeldekortUtbetalingsgrunnlagSak::utskriftUtenMK).collect(Collectors.joining(", "));
-            var vKIkkeA = kelvin.stream().filter(a -> arena.stream().noneMatch(a::likeNokVedtak))
-                .map(MeldekortUtbetalingsgrunnlagSak::utskriftUtenMK).collect(Collectors.joining(", "));
-            var mAIkkeK = arenaMK.stream().filter(a -> kelvinMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
-            var mKIkkeA = kelvinMK.stream().filter(a -> arenaMK.stream().noneMatch(a::equals)).collect(Collectors.toSet());
             if (arena.size() > kelvin.size()) {
-                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}",  vAIkkeK);
+                LOG.info("Maksimum AAP; fikk meldekort fra Arena som ikke er i Kelvin: {}, saksnummer: {}",  vAIkkeK, saksnummer);
             } else if (!arena.isEmpty()) {
                 var likeNokVedtak = arena.stream().allMatch(a -> kelvin.stream().anyMatch(a::likeNokVedtak));
                 var likeMk = kelvinMK.containsAll(arenaMK);
                 if (likeNokVedtak && likeMk) {
                     LOG.info("Maksimum AAP sammenligning likt svar fra arena og AAP-api");
                 } else {
-                    LOG.info("Maksimum AAP sammenligning lik størrelse ulikt innhold: arena: {} mk {} kelvin: {} mk {}", vAIkkeK, mAIkkeK, vKIkkeA, mKIkkeA);
+                    LOG.info("Maksimum AAP sammenligning lik størrelse ulikt innhold, saksnummer: {}", saksnummer);
                 }
             }
         } catch (Exception e) {
-            LOG.info("Maksimum AAP sammenligning av Arenadata for sak {} feilet med {}, {}", saksnummer.getVerdi(), e.getMessage(), e.getStackTrace());
+            LOG.info("Maksimum AAP sammenligning av Arenadata for sak " + saksnummer + "feilet.", e);
         }
     }
 

--- a/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
+++ b/domenetjenester/iay/src/main/java/no/nav/k9/abakus/registerdata/InnhentingSamletTjeneste.java
@@ -182,7 +182,7 @@ public class InnhentingSamletTjeneste {
                 }
             }
         } catch (Exception e) {
-            LOG.info("Maksimum AAP sammenligning av Arenadata for sak " + saksnummer + "feilet.", e);
+            LOG.info("Maksimum AAP sammenligning av Arenadata for sak {} feilet med {}, {}", saksnummer.getVerdi(), e.getMessage(), e.getStackTrace());
         }
     }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Vi ønsker ikke å logge ut meldekortene, her er det mye sensitiv informasjon. Logger ut saksnummeret så vi kan gi beskjed til AAP-teamet ved avvik.

### Løsning


### Andre endringer


---

### Sjekkliste for godkjenner

- [ ] Ingen uhensiktsmessig spesialbehandling av saker (hardkodede aktørId-er, saksnumre, org.nr som styrer forretningslogikk)
- [ ] Flyway-migrasjoner er vurdert (destruktive endringer, korrekt versjonering, påvirkning på økonomiske data)
- [ ] Sporbarhet: lenke til Jira, Slack-tråd, eller en tydelig beskrivelse av **hvorfor** endringen gjøres
